### PR TITLE
Added property tests for IFile and IFolder, bumped OwlCore.Storage to 0.15.0

### DIFF
--- a/src/AssertEx.cs
+++ b/src/AssertEx.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace OwlCore.Storage.CommonTests;
+
+/// <summary>
+/// Extended assertion helpers for common test scenarios.
+/// </summary>
+public static class AssertEx
+{
+    /// <summary>
+    /// Tests whether the code specified by <paramref name="action"/> throws an exception of type <typeparamref name="T"/>
+    /// or any type derived from <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The expected exception type, or a base type of the expected exception.</typeparam>
+    /// <param name="action">The async action to execute.</param>
+    /// <param name="message">The message to include in the exception when the assertion fails.</param>
+    /// <returns>The exception that was thrown.</returns>
+    /// <exception cref="AssertFailedException">Thrown if no exception or an incompatible exception type is thrown.</exception>
+    public static async Task<T> ThrowsExceptionAsync<T>(Func<Task> action, string? message = null) where T : Exception
+    {
+        try
+        {
+            await action();
+        }
+        catch (T ex)
+        {
+            // Success - the exception is of the expected type or derived from it
+            return ex;
+        }
+        catch (Exception ex)
+        {
+            var msg = message != null
+                ? $"{message} Expected exception type: <{typeof(T).FullName}>. Actual exception type: <{ex.GetType().FullName}>."
+                : $"Assert.ThrowsException failed. Expected exception type: <{typeof(T).FullName}>. Actual exception type: <{ex.GetType().FullName}>.";
+            throw new AssertFailedException(msg, ex);
+        }
+
+        var noExMsg = message != null
+            ? $"{message} Expected exception type: <{typeof(T).FullName}> but no exception was thrown."
+            : $"Assert.ThrowsException failed. Expected exception type: <{typeof(T).FullName}> but no exception was thrown.";
+        throw new AssertFailedException(noExMsg);
+    }
+
+    /// <summary>
+    /// Tests whether the code specified by <paramref name="action"/> throws an exception of type <typeparamref name="T"/>
+    /// or any type derived from <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The expected exception type, or a base type of the expected exception.</typeparam>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="message">The message to include in the exception when the assertion fails.</param>
+    /// <returns>The exception that was thrown.</returns>
+    /// <exception cref="AssertFailedException">Thrown if no exception or an incompatible exception type is thrown.</exception>
+    public static T ThrowsException<T>(Action action, string? message = null) where T : Exception
+    {
+        try
+        {
+            action();
+        }
+        catch (T ex)
+        {
+            // Success - the exception is of the expected type or derived from it
+            return ex;
+        }
+        catch (Exception ex)
+        {
+            var msg = message != null
+                ? $"{message} Expected exception type: <{typeof(T).FullName}>. Actual exception type: <{ex.GetType().FullName}>."
+                : $"Assert.ThrowsException failed. Expected exception type: <{typeof(T).FullName}>. Actual exception type: <{ex.GetType().FullName}>.";
+            throw new AssertFailedException(msg, ex);
+        }
+
+        var noExMsg = message != null
+            ? $"{message} Expected exception type: <{typeof(T).FullName}> but no exception was thrown."
+            : $"Assert.ThrowsException failed. Expected exception type: <{typeof(T).FullName}> but no exception was thrown.";
+        throw new AssertFailedException(noExMsg);
+    }
+}

--- a/src/CommonIFileTests.CreatedAt.cs
+++ b/src/CommonIFileTests.CreatedAt.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace OwlCore.Storage.CommonTests;
+
+public abstract partial class CommonIFileTests
+{
+    [TestMethod]
+    public async Task CreatedAt_PropertyName_MatchesInterfaceMember()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ICreatedAt createdAt)
+            return;
+
+        Assert.AreEqual(nameof(ICreatedAt.CreatedAt), createdAt.CreatedAt.Name);
+    }
+
+    [TestMethod]
+    public async Task CreatedAt_GetValueAsync_ReturnsValue()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ICreatedAt createdAt)
+            return;
+
+        var value = await createdAt.CreatedAt.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(value);
+        Assert.AreNotEqual(DateTime.MinValue, value.Value);
+    }
+
+    [TestMethod]
+    public async Task CreatedAt_GetValueAsync_ImmediateCancellation()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ICreatedAt createdAt)
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await createdAt.CreatedAt.GetValueAsync(cts.Token));
+    }
+
+    [TestMethod]
+    public async Task CreatedAt_Watcher_ReturnsNewInstanceEachCall()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ICreatedAt { CreatedAt: IMutableStorageProperty<DateTime?> prop })
+            return;
+
+        using var watcher1 = await prop.GetWatcherAsync(CancellationToken.None);
+        using var watcher2 = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreNotSame(watcher1, watcher2);
+    }
+
+    [TestMethod]
+    public async Task CreatedAt_Watcher_PropertyReferenceIsCorrect()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ICreatedAt { CreatedAt: IMutableStorageProperty<DateTime?> prop })
+            return;
+
+        using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreSame(prop, watcher.Property);
+    }
+
+    [TestMethod]
+    public async Task CreatedAt_UpdateValueAsync_PersistsChange()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ICreatedAt { CreatedAt: IModifiableStorageProperty<DateTime?> prop })
+            return;
+
+        var newValue = DateTime.Now.AddDays(-1);
+        await prop.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await prop.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(retrieved);
+        Assert.AreEqual(newValue.Year, retrieved.Value.Year);
+        Assert.AreEqual(newValue.Month, retrieved.Value.Month);
+        Assert.AreEqual(newValue.Day, retrieved.Value.Day);
+        Assert.AreEqual(newValue.Hour, retrieved.Value.Hour);
+        Assert.AreEqual(newValue.Minute, retrieved.Value.Minute);
+        Assert.AreEqual(newValue.Second, retrieved.Value.Second);
+    }
+
+    [TestMethod]
+    public async Task CreatedAt_UpdateValueAsync_NullThrows()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ICreatedAt { CreatedAt: IModifiableStorageProperty<DateTime?> prop })
+            return;
+
+        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            await prop.UpdateValueAsync(null, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task CreatedAt_UpdateValueAsync_ImmediateCancellation()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ICreatedAt { CreatedAt: IModifiableStorageProperty<DateTime?> prop })
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await prop.UpdateValueAsync(DateTime.Now, cts.Token));
+    }
+}

--- a/src/CommonIFileTests.CreatedAt.cs
+++ b/src/CommonIFileTests.CreatedAt.cs
@@ -25,8 +25,43 @@ public abstract partial class CommonIFileTests
             return;
 
         var value = await createdAt.CreatedAt.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(value);
-        Assert.AreNotEqual(DateTime.MinValue, value.Value);
+
+        switch (CreatedAtAvailability)
+        {
+            case PropertyValueAvailability.Always:
+                Assert.IsNotNull(value, "CreatedAt should always have a value for this implementation.");
+                Assert.AreNotEqual(DateTime.MinValue, value.Value);
+                break;
+
+            case PropertyValueAvailability.Maybe:
+                if (value is not null)
+                    Assert.AreNotEqual(DateTime.MinValue, value.Value);
+                break;
+        }
+    }
+
+    [TestMethod]
+    public async Task CreatedAt_CreateWithKnownTimestamp_ReturnsCorrectValue()
+    {
+        var expectedTimestamp = DateTime.UtcNow.AddDays(-30);
+        var file = await CreateFileWithCreatedAtAsync(expectedTimestamp);
+        
+        // Skip if implementation doesn't support creating files with known timestamps
+        if (file is null)
+            return;
+
+        if (file is not ICreatedAt createdAt)
+        {
+            Assert.Fail("CreateFileWithCreatedAtAsync returned a file that doesn't implement ICreatedAt.");
+            return;
+        }
+
+        var value = await createdAt.CreatedAt.GetValueAsync(CancellationToken.None);
+        
+        Assert.IsNotNull(value, "CreatedAt should have a value when created with a known timestamp.");
+        
+        var diff = Math.Abs((value.Value.ToUniversalTime() - expectedTimestamp).TotalSeconds);
+        Assert.IsTrue(diff < 2, $"CreatedAt should match the requested timestamp. Expected={expectedTimestamp:O}, Actual={value:O}, Diff={diff:F2}s");
     }
 
     [TestMethod]
@@ -66,50 +101,5 @@ public abstract partial class CommonIFileTests
         using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
 
         Assert.AreSame(prop, watcher.Property);
-    }
-
-    [TestMethod]
-    public async Task CreatedAt_UpdateValueAsync_PersistsChange()
-    {
-        var file = await CreateFileAsync();
-        if (file is not ICreatedAt { CreatedAt: IModifiableStorageProperty<DateTime?> prop })
-            return;
-
-        var newValue = DateTime.Now.AddDays(-1);
-        await prop.UpdateValueAsync(newValue, CancellationToken.None);
-
-        var retrieved = await prop.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(retrieved);
-        Assert.AreEqual(newValue.Year, retrieved.Value.Year);
-        Assert.AreEqual(newValue.Month, retrieved.Value.Month);
-        Assert.AreEqual(newValue.Day, retrieved.Value.Day);
-        Assert.AreEqual(newValue.Hour, retrieved.Value.Hour);
-        Assert.AreEqual(newValue.Minute, retrieved.Value.Minute);
-        Assert.AreEqual(newValue.Second, retrieved.Value.Second);
-    }
-
-    [TestMethod]
-    public async Task CreatedAt_UpdateValueAsync_NullThrows()
-    {
-        var file = await CreateFileAsync();
-        if (file is not ICreatedAt { CreatedAt: IModifiableStorageProperty<DateTime?> prop })
-            return;
-
-        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
-            await prop.UpdateValueAsync(null, CancellationToken.None));
-    }
-
-    [TestMethod]
-    public async Task CreatedAt_UpdateValueAsync_ImmediateCancellation()
-    {
-        var file = await CreateFileAsync();
-        if (file is not ICreatedAt { CreatedAt: IModifiableStorageProperty<DateTime?> prop })
-            return;
-
-        var cts = new CancellationTokenSource();
-        cts.Cancel();
-
-        Assert.ThrowsException<OperationCanceledException>(() =>
-            prop.UpdateValueAsync(DateTime.Now, cts.Token));
     }
 }

--- a/src/CommonIFileTests.CreatedAt.cs
+++ b/src/CommonIFileTests.CreatedAt.cs
@@ -39,8 +39,8 @@ public abstract partial class CommonIFileTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await createdAt.CreatedAt.GetValueAsync(cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            createdAt.CreatedAt.GetValueAsync(cts.Token));
     }
 
     [TestMethod]
@@ -109,7 +109,7 @@ public abstract partial class CommonIFileTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await prop.UpdateValueAsync(DateTime.Now, cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            prop.UpdateValueAsync(DateTime.Now, cts.Token));
     }
 }

--- a/src/CommonIFileTests.CreatedAtOffset.cs
+++ b/src/CommonIFileTests.CreatedAtOffset.cs
@@ -39,8 +39,8 @@ public abstract partial class CommonIFileTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await createdAtOffset.CreatedAtOffset.GetValueAsync(cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            createdAtOffset.CreatedAtOffset.GetValueAsync(cts.Token));
     }
 
     [TestMethod]
@@ -109,7 +109,7 @@ public abstract partial class CommonIFileTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
     }
 }

--- a/src/CommonIFileTests.CreatedAtOffset.cs
+++ b/src/CommonIFileTests.CreatedAtOffset.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace OwlCore.Storage.CommonTests;
+
+public abstract partial class CommonIFileTests
+{
+    [TestMethod]
+    public async Task CreatedAtOffset_PropertyName_MatchesInterfaceMember()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ICreatedAtOffset createdAtOffset)
+            return;
+
+        Assert.AreEqual(nameof(ICreatedAtOffset.CreatedAtOffset), createdAtOffset.CreatedAtOffset.Name);
+    }
+
+    [TestMethod]
+    public async Task CreatedAtOffset_GetValueAsync_ReturnsValue()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ICreatedAtOffset createdAtOffset)
+            return;
+
+        var value = await createdAtOffset.CreatedAtOffset.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(value);
+        Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+    }
+
+    [TestMethod]
+    public async Task CreatedAtOffset_GetValueAsync_ImmediateCancellation()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ICreatedAtOffset createdAtOffset)
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await createdAtOffset.CreatedAtOffset.GetValueAsync(cts.Token));
+    }
+
+    [TestMethod]
+    public async Task CreatedAtOffset_Watcher_ReturnsNewInstanceEachCall()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ICreatedAtOffset { CreatedAtOffset: IMutableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        using var watcher1 = await prop.GetWatcherAsync(CancellationToken.None);
+        using var watcher2 = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreNotSame(watcher1, watcher2);
+    }
+
+    [TestMethod]
+    public async Task CreatedAtOffset_Watcher_PropertyReferenceIsCorrect()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ICreatedAtOffset { CreatedAtOffset: IMutableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreSame(prop, watcher.Property);
+    }
+
+    [TestMethod]
+    public async Task CreatedAtOffset_UpdateValueAsync_PersistsChange()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ICreatedAtOffset { CreatedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        var newValue = DateTimeOffset.Now.AddDays(-1);
+        await prop.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await prop.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(retrieved);
+        Assert.AreEqual(newValue.UtcDateTime.Year, retrieved.Value.UtcDateTime.Year);
+        Assert.AreEqual(newValue.UtcDateTime.Month, retrieved.Value.UtcDateTime.Month);
+        Assert.AreEqual(newValue.UtcDateTime.Day, retrieved.Value.UtcDateTime.Day);
+        Assert.AreEqual(newValue.UtcDateTime.Hour, retrieved.Value.UtcDateTime.Hour);
+        Assert.AreEqual(newValue.UtcDateTime.Minute, retrieved.Value.UtcDateTime.Minute);
+        Assert.AreEqual(newValue.UtcDateTime.Second, retrieved.Value.UtcDateTime.Second);
+    }
+
+    [TestMethod]
+    public async Task CreatedAtOffset_UpdateValueAsync_NullThrows()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ICreatedAtOffset { CreatedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            await prop.UpdateValueAsync(null, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task CreatedAtOffset_UpdateValueAsync_ImmediateCancellation()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ICreatedAtOffset { CreatedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
+    }
+}

--- a/src/CommonIFileTests.CreatedAtOffset.cs
+++ b/src/CommonIFileTests.CreatedAtOffset.cs
@@ -25,8 +25,19 @@ public abstract partial class CommonIFileTests
             return;
 
         var value = await createdAtOffset.CreatedAtOffset.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(value);
-        Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+
+        switch (CreatedAtAvailability)
+        {
+            case PropertyValueAvailability.Always:
+                Assert.IsNotNull(value, "CreatedAtOffset should always have a value for this implementation.");
+                Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+                break;
+
+            case PropertyValueAvailability.Maybe:
+                if (value is not null)
+                    Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+                break;
+        }
     }
 
     [TestMethod]
@@ -66,50 +77,5 @@ public abstract partial class CommonIFileTests
         using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
 
         Assert.AreSame(prop, watcher.Property);
-    }
-
-    [TestMethod]
-    public async Task CreatedAtOffset_UpdateValueAsync_PersistsChange()
-    {
-        var file = await CreateFileAsync();
-        if (file is not ICreatedAtOffset { CreatedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
-            return;
-
-        var newValue = DateTimeOffset.Now.AddDays(-1);
-        await prop.UpdateValueAsync(newValue, CancellationToken.None);
-
-        var retrieved = await prop.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(retrieved);
-        Assert.AreEqual(newValue.UtcDateTime.Year, retrieved.Value.UtcDateTime.Year);
-        Assert.AreEqual(newValue.UtcDateTime.Month, retrieved.Value.UtcDateTime.Month);
-        Assert.AreEqual(newValue.UtcDateTime.Day, retrieved.Value.UtcDateTime.Day);
-        Assert.AreEqual(newValue.UtcDateTime.Hour, retrieved.Value.UtcDateTime.Hour);
-        Assert.AreEqual(newValue.UtcDateTime.Minute, retrieved.Value.UtcDateTime.Minute);
-        Assert.AreEqual(newValue.UtcDateTime.Second, retrieved.Value.UtcDateTime.Second);
-    }
-
-    [TestMethod]
-    public async Task CreatedAtOffset_UpdateValueAsync_NullThrows()
-    {
-        var file = await CreateFileAsync();
-        if (file is not ICreatedAtOffset { CreatedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
-            return;
-
-        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
-            await prop.UpdateValueAsync(null, CancellationToken.None));
-    }
-
-    [TestMethod]
-    public async Task CreatedAtOffset_UpdateValueAsync_ImmediateCancellation()
-    {
-        var file = await CreateFileAsync();
-        if (file is not ICreatedAtOffset { CreatedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
-            return;
-
-        var cts = new CancellationTokenSource();
-        cts.Cancel();
-
-        Assert.ThrowsException<OperationCanceledException>(() =>
-            prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
     }
 }

--- a/src/CommonIFileTests.LastAccessedAt.cs
+++ b/src/CommonIFileTests.LastAccessedAt.cs
@@ -39,8 +39,8 @@ public abstract partial class CommonIFileTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await lastAccessedAt.LastAccessedAt.GetValueAsync(cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            lastAccessedAt.LastAccessedAt.GetValueAsync(cts.Token));
     }
 
     [TestMethod]
@@ -109,7 +109,7 @@ public abstract partial class CommonIFileTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await prop.UpdateValueAsync(DateTime.Now, cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            prop.UpdateValueAsync(DateTime.Now, cts.Token));
     }
 }

--- a/src/CommonIFileTests.LastAccessedAt.cs
+++ b/src/CommonIFileTests.LastAccessedAt.cs
@@ -25,8 +25,43 @@ public abstract partial class CommonIFileTests
             return;
 
         var value = await lastAccessedAt.LastAccessedAt.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(value);
-        Assert.AreNotEqual(DateTime.MinValue, value.Value);
+
+        switch (LastAccessedAtAvailability)
+        {
+            case PropertyValueAvailability.Always:
+                Assert.IsNotNull(value, "LastAccessedAt should always have a value for this implementation.");
+                Assert.AreNotEqual(DateTime.MinValue, value.Value);
+                break;
+
+            case PropertyValueAvailability.Maybe:
+                if (value is not null)
+                    Assert.AreNotEqual(DateTime.MinValue, value.Value);
+                break;
+        }
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAt_CreateWithKnownTimestamp_ReturnsCorrectValue()
+    {
+        var expectedTimestamp = DateTime.UtcNow.AddDays(-7);
+        var file = await CreateFileWithLastAccessedAtAsync(expectedTimestamp);
+        
+        // Skip if implementation doesn't support creating files with known timestamps
+        if (file is null)
+            return;
+
+        if (file is not ILastAccessedAt lastAccessedAt)
+        {
+            Assert.Fail("CreateFileWithLastAccessedAtAsync returned a file that doesn't implement ILastAccessedAt.");
+            return;
+        }
+
+        var value = await lastAccessedAt.LastAccessedAt.GetValueAsync(CancellationToken.None);
+        
+        Assert.IsNotNull(value, "LastAccessedAt should have a value when created with a known timestamp.");
+        
+        var diff = Math.Abs((value.Value.ToUniversalTime() - expectedTimestamp).TotalSeconds);
+        Assert.IsTrue(diff < 2, $"LastAccessedAt should match the requested timestamp. Expected={expectedTimestamp:O}, Actual={value:O}, Diff={diff:F2}s");
     }
 
     [TestMethod]
@@ -66,50 +101,5 @@ public abstract partial class CommonIFileTests
         using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
 
         Assert.AreSame(prop, watcher.Property);
-    }
-
-    [TestMethod]
-    public async Task LastAccessedAt_UpdateValueAsync_PersistsChange()
-    {
-        var file = await CreateFileAsync();
-        if (file is not ILastAccessedAt { LastAccessedAt: IModifiableStorageProperty<DateTime?> prop })
-            return;
-
-        var newValue = DateTime.Now.AddDays(-1);
-        await prop.UpdateValueAsync(newValue, CancellationToken.None);
-
-        var retrieved = await prop.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(retrieved);
-        Assert.AreEqual(newValue.Year, retrieved.Value.Year);
-        Assert.AreEqual(newValue.Month, retrieved.Value.Month);
-        Assert.AreEqual(newValue.Day, retrieved.Value.Day);
-        Assert.AreEqual(newValue.Hour, retrieved.Value.Hour);
-        Assert.AreEqual(newValue.Minute, retrieved.Value.Minute);
-        Assert.AreEqual(newValue.Second, retrieved.Value.Second);
-    }
-
-    [TestMethod]
-    public async Task LastAccessedAt_UpdateValueAsync_NullThrows()
-    {
-        var file = await CreateFileAsync();
-        if (file is not ILastAccessedAt { LastAccessedAt: IModifiableStorageProperty<DateTime?> prop })
-            return;
-
-        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
-            await prop.UpdateValueAsync(null, CancellationToken.None));
-    }
-
-    [TestMethod]
-    public async Task LastAccessedAt_UpdateValueAsync_ImmediateCancellation()
-    {
-        var file = await CreateFileAsync();
-        if (file is not ILastAccessedAt { LastAccessedAt: IModifiableStorageProperty<DateTime?> prop })
-            return;
-
-        var cts = new CancellationTokenSource();
-        cts.Cancel();
-
-        Assert.ThrowsException<OperationCanceledException>(() =>
-            prop.UpdateValueAsync(DateTime.Now, cts.Token));
     }
 }

--- a/src/CommonIFileTests.LastAccessedAt.cs
+++ b/src/CommonIFileTests.LastAccessedAt.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace OwlCore.Storage.CommonTests;
+
+public abstract partial class CommonIFileTests
+{
+    [TestMethod]
+    public async Task LastAccessedAt_PropertyName_MatchesInterfaceMember()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastAccessedAt lastAccessedAt)
+            return;
+
+        Assert.AreEqual(nameof(ILastAccessedAt.LastAccessedAt), lastAccessedAt.LastAccessedAt.Name);
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAt_GetValueAsync_ReturnsValue()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastAccessedAt lastAccessedAt)
+            return;
+
+        var value = await lastAccessedAt.LastAccessedAt.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(value);
+        Assert.AreNotEqual(DateTime.MinValue, value.Value);
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAt_GetValueAsync_ImmediateCancellation()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastAccessedAt lastAccessedAt)
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await lastAccessedAt.LastAccessedAt.GetValueAsync(cts.Token));
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAt_Watcher_ReturnsNewInstanceEachCall()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastAccessedAt { LastAccessedAt: IMutableStorageProperty<DateTime?> prop })
+            return;
+
+        using var watcher1 = await prop.GetWatcherAsync(CancellationToken.None);
+        using var watcher2 = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreNotSame(watcher1, watcher2);
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAt_Watcher_PropertyReferenceIsCorrect()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastAccessedAt { LastAccessedAt: IMutableStorageProperty<DateTime?> prop })
+            return;
+
+        using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreSame(prop, watcher.Property);
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAt_UpdateValueAsync_PersistsChange()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastAccessedAt { LastAccessedAt: IModifiableStorageProperty<DateTime?> prop })
+            return;
+
+        var newValue = DateTime.Now.AddDays(-1);
+        await prop.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await prop.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(retrieved);
+        Assert.AreEqual(newValue.Year, retrieved.Value.Year);
+        Assert.AreEqual(newValue.Month, retrieved.Value.Month);
+        Assert.AreEqual(newValue.Day, retrieved.Value.Day);
+        Assert.AreEqual(newValue.Hour, retrieved.Value.Hour);
+        Assert.AreEqual(newValue.Minute, retrieved.Value.Minute);
+        Assert.AreEqual(newValue.Second, retrieved.Value.Second);
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAt_UpdateValueAsync_NullThrows()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastAccessedAt { LastAccessedAt: IModifiableStorageProperty<DateTime?> prop })
+            return;
+
+        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            await prop.UpdateValueAsync(null, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAt_UpdateValueAsync_ImmediateCancellation()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastAccessedAt { LastAccessedAt: IModifiableStorageProperty<DateTime?> prop })
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await prop.UpdateValueAsync(DateTime.Now, cts.Token));
+    }
+}

--- a/src/CommonIFileTests.LastAccessedAtOffset.cs
+++ b/src/CommonIFileTests.LastAccessedAtOffset.cs
@@ -39,8 +39,8 @@ public abstract partial class CommonIFileTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await lastAccessedAtOffset.LastAccessedAtOffset.GetValueAsync(cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            lastAccessedAtOffset.LastAccessedAtOffset.GetValueAsync(cts.Token));
     }
 
     [TestMethod]
@@ -109,7 +109,7 @@ public abstract partial class CommonIFileTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
     }
 }

--- a/src/CommonIFileTests.LastAccessedAtOffset.cs
+++ b/src/CommonIFileTests.LastAccessedAtOffset.cs
@@ -25,8 +25,19 @@ public abstract partial class CommonIFileTests
             return;
 
         var value = await lastAccessedAtOffset.LastAccessedAtOffset.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(value);
-        Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+
+        switch (LastAccessedAtAvailability)
+        {
+            case PropertyValueAvailability.Always:
+                Assert.IsNotNull(value, "LastAccessedAtOffset should always have a value for this implementation.");
+                Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+                break;
+
+            case PropertyValueAvailability.Maybe:
+                if (value is not null)
+                    Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+                break;
+        }
     }
 
     [TestMethod]
@@ -66,50 +77,5 @@ public abstract partial class CommonIFileTests
         using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
 
         Assert.AreSame(prop, watcher.Property);
-    }
-
-    [TestMethod]
-    public async Task LastAccessedAtOffset_UpdateValueAsync_PersistsChange()
-    {
-        var file = await CreateFileAsync();
-        if (file is not ILastAccessedAtOffset { LastAccessedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
-            return;
-
-        var newValue = DateTimeOffset.Now.AddDays(-1);
-        await prop.UpdateValueAsync(newValue, CancellationToken.None);
-
-        var retrieved = await prop.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(retrieved);
-        Assert.AreEqual(newValue.UtcDateTime.Year, retrieved.Value.UtcDateTime.Year);
-        Assert.AreEqual(newValue.UtcDateTime.Month, retrieved.Value.UtcDateTime.Month);
-        Assert.AreEqual(newValue.UtcDateTime.Day, retrieved.Value.UtcDateTime.Day);
-        Assert.AreEqual(newValue.UtcDateTime.Hour, retrieved.Value.UtcDateTime.Hour);
-        Assert.AreEqual(newValue.UtcDateTime.Minute, retrieved.Value.UtcDateTime.Minute);
-        Assert.AreEqual(newValue.UtcDateTime.Second, retrieved.Value.UtcDateTime.Second);
-    }
-
-    [TestMethod]
-    public async Task LastAccessedAtOffset_UpdateValueAsync_NullThrows()
-    {
-        var file = await CreateFileAsync();
-        if (file is not ILastAccessedAtOffset { LastAccessedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
-            return;
-
-        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
-            await prop.UpdateValueAsync(null, CancellationToken.None));
-    }
-
-    [TestMethod]
-    public async Task LastAccessedAtOffset_UpdateValueAsync_ImmediateCancellation()
-    {
-        var file = await CreateFileAsync();
-        if (file is not ILastAccessedAtOffset { LastAccessedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
-            return;
-
-        var cts = new CancellationTokenSource();
-        cts.Cancel();
-
-        Assert.ThrowsException<OperationCanceledException>(() =>
-            prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
     }
 }

--- a/src/CommonIFileTests.LastAccessedAtOffset.cs
+++ b/src/CommonIFileTests.LastAccessedAtOffset.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace OwlCore.Storage.CommonTests;
+
+public abstract partial class CommonIFileTests
+{
+    [TestMethod]
+    public async Task LastAccessedAtOffset_PropertyName_MatchesInterfaceMember()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastAccessedAtOffset lastAccessedAtOffset)
+            return;
+
+        Assert.AreEqual(nameof(ILastAccessedAtOffset.LastAccessedAtOffset), lastAccessedAtOffset.LastAccessedAtOffset.Name);
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAtOffset_GetValueAsync_ReturnsValue()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastAccessedAtOffset lastAccessedAtOffset)
+            return;
+
+        var value = await lastAccessedAtOffset.LastAccessedAtOffset.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(value);
+        Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAtOffset_GetValueAsync_ImmediateCancellation()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastAccessedAtOffset lastAccessedAtOffset)
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await lastAccessedAtOffset.LastAccessedAtOffset.GetValueAsync(cts.Token));
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAtOffset_Watcher_ReturnsNewInstanceEachCall()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastAccessedAtOffset { LastAccessedAtOffset: IMutableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        using var watcher1 = await prop.GetWatcherAsync(CancellationToken.None);
+        using var watcher2 = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreNotSame(watcher1, watcher2);
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAtOffset_Watcher_PropertyReferenceIsCorrect()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastAccessedAtOffset { LastAccessedAtOffset: IMutableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreSame(prop, watcher.Property);
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAtOffset_UpdateValueAsync_PersistsChange()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastAccessedAtOffset { LastAccessedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        var newValue = DateTimeOffset.Now.AddDays(-1);
+        await prop.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await prop.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(retrieved);
+        Assert.AreEqual(newValue.UtcDateTime.Year, retrieved.Value.UtcDateTime.Year);
+        Assert.AreEqual(newValue.UtcDateTime.Month, retrieved.Value.UtcDateTime.Month);
+        Assert.AreEqual(newValue.UtcDateTime.Day, retrieved.Value.UtcDateTime.Day);
+        Assert.AreEqual(newValue.UtcDateTime.Hour, retrieved.Value.UtcDateTime.Hour);
+        Assert.AreEqual(newValue.UtcDateTime.Minute, retrieved.Value.UtcDateTime.Minute);
+        Assert.AreEqual(newValue.UtcDateTime.Second, retrieved.Value.UtcDateTime.Second);
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAtOffset_UpdateValueAsync_NullThrows()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastAccessedAtOffset { LastAccessedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            await prop.UpdateValueAsync(null, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAtOffset_UpdateValueAsync_ImmediateCancellation()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastAccessedAtOffset { LastAccessedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
+    }
+}

--- a/src/CommonIFileTests.LastModifiedAt.cs
+++ b/src/CommonIFileTests.LastModifiedAt.cs
@@ -25,8 +25,43 @@ public abstract partial class CommonIFileTests
             return;
 
         var value = await lastModifiedAt.LastModifiedAt.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(value);
-        Assert.AreNotEqual(DateTime.MinValue, value.Value);
+
+        switch (LastModifiedAtAvailability)
+        {
+            case PropertyValueAvailability.Always:
+                Assert.IsNotNull(value, "LastModifiedAt should always have a value for this implementation.");
+                Assert.AreNotEqual(DateTime.MinValue, value.Value);
+                break;
+
+            case PropertyValueAvailability.Maybe:
+                if (value is not null)
+                    Assert.AreNotEqual(DateTime.MinValue, value.Value);
+                break;
+        }
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAt_CreateWithKnownTimestamp_ReturnsCorrectValue()
+    {
+        var expectedTimestamp = DateTime.UtcNow.AddDays(-15);
+        var file = await CreateFileWithLastModifiedAtAsync(expectedTimestamp);
+        
+        // Skip if implementation doesn't support creating files with known timestamps
+        if (file is null)
+            return;
+
+        if (file is not ILastModifiedAt lastModifiedAt)
+        {
+            Assert.Fail("CreateFileWithLastModifiedAtAsync returned a file that doesn't implement ILastModifiedAt.");
+            return;
+        }
+
+        var value = await lastModifiedAt.LastModifiedAt.GetValueAsync(CancellationToken.None);
+        
+        Assert.IsNotNull(value, "LastModifiedAt should have a value when created with a known timestamp.");
+        
+        var diff = Math.Abs((value.Value.ToUniversalTime() - expectedTimestamp).TotalSeconds);
+        Assert.IsTrue(diff < 2, $"LastModifiedAt should match the requested timestamp. Expected={expectedTimestamp:O}, Actual={value:O}, Diff={diff:F2}s");
     }
 
     [TestMethod]
@@ -66,50 +101,5 @@ public abstract partial class CommonIFileTests
         using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
 
         Assert.AreSame(prop, watcher.Property);
-    }
-
-    [TestMethod]
-    public async Task LastModifiedAt_UpdateValueAsync_PersistsChange()
-    {
-        var file = await CreateFileAsync();
-        if (file is not ILastModifiedAt { LastModifiedAt: IModifiableStorageProperty<DateTime?> prop })
-            return;
-
-        var newValue = DateTime.Now.AddDays(-1);
-        await prop.UpdateValueAsync(newValue, CancellationToken.None);
-
-        var retrieved = await prop.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(retrieved);
-        Assert.AreEqual(newValue.Year, retrieved.Value.Year);
-        Assert.AreEqual(newValue.Month, retrieved.Value.Month);
-        Assert.AreEqual(newValue.Day, retrieved.Value.Day);
-        Assert.AreEqual(newValue.Hour, retrieved.Value.Hour);
-        Assert.AreEqual(newValue.Minute, retrieved.Value.Minute);
-        Assert.AreEqual(newValue.Second, retrieved.Value.Second);
-    }
-
-    [TestMethod]
-    public async Task LastModifiedAt_UpdateValueAsync_NullThrows()
-    {
-        var file = await CreateFileAsync();
-        if (file is not ILastModifiedAt { LastModifiedAt: IModifiableStorageProperty<DateTime?> prop })
-            return;
-
-        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
-            await prop.UpdateValueAsync(null, CancellationToken.None));
-    }
-
-    [TestMethod]
-    public async Task LastModifiedAt_UpdateValueAsync_ImmediateCancellation()
-    {
-        var file = await CreateFileAsync();
-        if (file is not ILastModifiedAt { LastModifiedAt: IModifiableStorageProperty<DateTime?> prop })
-            return;
-
-        var cts = new CancellationTokenSource();
-        cts.Cancel();
-
-        Assert.ThrowsException<OperationCanceledException>(() =>
-            prop.UpdateValueAsync(DateTime.Now, cts.Token));
     }
 }

--- a/src/CommonIFileTests.LastModifiedAt.cs
+++ b/src/CommonIFileTests.LastModifiedAt.cs
@@ -39,8 +39,8 @@ public abstract partial class CommonIFileTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await lastModifiedAt.LastModifiedAt.GetValueAsync(cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            lastModifiedAt.LastModifiedAt.GetValueAsync(cts.Token));
     }
 
     [TestMethod]
@@ -109,7 +109,7 @@ public abstract partial class CommonIFileTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await prop.UpdateValueAsync(DateTime.Now, cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            prop.UpdateValueAsync(DateTime.Now, cts.Token));
     }
 }

--- a/src/CommonIFileTests.LastModifiedAt.cs
+++ b/src/CommonIFileTests.LastModifiedAt.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace OwlCore.Storage.CommonTests;
+
+public abstract partial class CommonIFileTests
+{
+    [TestMethod]
+    public async Task LastModifiedAt_PropertyName_MatchesInterfaceMember()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastModifiedAt lastModifiedAt)
+            return;
+
+        Assert.AreEqual(nameof(ILastModifiedAt.LastModifiedAt), lastModifiedAt.LastModifiedAt.Name);
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAt_GetValueAsync_ReturnsValue()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastModifiedAt lastModifiedAt)
+            return;
+
+        var value = await lastModifiedAt.LastModifiedAt.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(value);
+        Assert.AreNotEqual(DateTime.MinValue, value.Value);
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAt_GetValueAsync_ImmediateCancellation()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastModifiedAt lastModifiedAt)
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await lastModifiedAt.LastModifiedAt.GetValueAsync(cts.Token));
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAt_Watcher_ReturnsNewInstanceEachCall()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastModifiedAt { LastModifiedAt: IMutableStorageProperty<DateTime?> prop })
+            return;
+
+        using var watcher1 = await prop.GetWatcherAsync(CancellationToken.None);
+        using var watcher2 = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreNotSame(watcher1, watcher2);
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAt_Watcher_PropertyReferenceIsCorrect()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastModifiedAt { LastModifiedAt: IMutableStorageProperty<DateTime?> prop })
+            return;
+
+        using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreSame(prop, watcher.Property);
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAt_UpdateValueAsync_PersistsChange()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastModifiedAt { LastModifiedAt: IModifiableStorageProperty<DateTime?> prop })
+            return;
+
+        var newValue = DateTime.Now.AddDays(-1);
+        await prop.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await prop.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(retrieved);
+        Assert.AreEqual(newValue.Year, retrieved.Value.Year);
+        Assert.AreEqual(newValue.Month, retrieved.Value.Month);
+        Assert.AreEqual(newValue.Day, retrieved.Value.Day);
+        Assert.AreEqual(newValue.Hour, retrieved.Value.Hour);
+        Assert.AreEqual(newValue.Minute, retrieved.Value.Minute);
+        Assert.AreEqual(newValue.Second, retrieved.Value.Second);
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAt_UpdateValueAsync_NullThrows()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastModifiedAt { LastModifiedAt: IModifiableStorageProperty<DateTime?> prop })
+            return;
+
+        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            await prop.UpdateValueAsync(null, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAt_UpdateValueAsync_ImmediateCancellation()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastModifiedAt { LastModifiedAt: IModifiableStorageProperty<DateTime?> prop })
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await prop.UpdateValueAsync(DateTime.Now, cts.Token));
+    }
+}

--- a/src/CommonIFileTests.LastModifiedAtOffset.cs
+++ b/src/CommonIFileTests.LastModifiedAtOffset.cs
@@ -39,8 +39,8 @@ public abstract partial class CommonIFileTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await lastModifiedAtOffset.LastModifiedAtOffset.GetValueAsync(cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            lastModifiedAtOffset.LastModifiedAtOffset.GetValueAsync(cts.Token));
     }
 
     [TestMethod]
@@ -109,7 +109,7 @@ public abstract partial class CommonIFileTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
     }
 }

--- a/src/CommonIFileTests.LastModifiedAtOffset.cs
+++ b/src/CommonIFileTests.LastModifiedAtOffset.cs
@@ -25,8 +25,19 @@ public abstract partial class CommonIFileTests
             return;
 
         var value = await lastModifiedAtOffset.LastModifiedAtOffset.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(value);
-        Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+
+        switch (LastModifiedAtAvailability)
+        {
+            case PropertyValueAvailability.Always:
+                Assert.IsNotNull(value, "LastModifiedAtOffset should always have a value for this implementation.");
+                Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+                break;
+
+            case PropertyValueAvailability.Maybe:
+                if (value is not null)
+                    Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+                break;
+        }
     }
 
     [TestMethod]
@@ -66,50 +77,5 @@ public abstract partial class CommonIFileTests
         using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
 
         Assert.AreSame(prop, watcher.Property);
-    }
-
-    [TestMethod]
-    public async Task LastModifiedAtOffset_UpdateValueAsync_PersistsChange()
-    {
-        var file = await CreateFileAsync();
-        if (file is not ILastModifiedAtOffset { LastModifiedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
-            return;
-
-        var newValue = DateTimeOffset.Now.AddDays(-1);
-        await prop.UpdateValueAsync(newValue, CancellationToken.None);
-
-        var retrieved = await prop.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(retrieved);
-        Assert.AreEqual(newValue.UtcDateTime.Year, retrieved.Value.UtcDateTime.Year);
-        Assert.AreEqual(newValue.UtcDateTime.Month, retrieved.Value.UtcDateTime.Month);
-        Assert.AreEqual(newValue.UtcDateTime.Day, retrieved.Value.UtcDateTime.Day);
-        Assert.AreEqual(newValue.UtcDateTime.Hour, retrieved.Value.UtcDateTime.Hour);
-        Assert.AreEqual(newValue.UtcDateTime.Minute, retrieved.Value.UtcDateTime.Minute);
-        Assert.AreEqual(newValue.UtcDateTime.Second, retrieved.Value.UtcDateTime.Second);
-    }
-
-    [TestMethod]
-    public async Task LastModifiedAtOffset_UpdateValueAsync_NullThrows()
-    {
-        var file = await CreateFileAsync();
-        if (file is not ILastModifiedAtOffset { LastModifiedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
-            return;
-
-        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
-            await prop.UpdateValueAsync(null, CancellationToken.None));
-    }
-
-    [TestMethod]
-    public async Task LastModifiedAtOffset_UpdateValueAsync_ImmediateCancellation()
-    {
-        var file = await CreateFileAsync();
-        if (file is not ILastModifiedAtOffset { LastModifiedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
-            return;
-
-        var cts = new CancellationTokenSource();
-        cts.Cancel();
-
-        Assert.ThrowsException<OperationCanceledException>(() =>
-            prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
     }
 }

--- a/src/CommonIFileTests.LastModifiedAtOffset.cs
+++ b/src/CommonIFileTests.LastModifiedAtOffset.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace OwlCore.Storage.CommonTests;
+
+public abstract partial class CommonIFileTests
+{
+    [TestMethod]
+    public async Task LastModifiedAtOffset_PropertyName_MatchesInterfaceMember()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastModifiedAtOffset lastModifiedAtOffset)
+            return;
+
+        Assert.AreEqual(nameof(ILastModifiedAtOffset.LastModifiedAtOffset), lastModifiedAtOffset.LastModifiedAtOffset.Name);
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAtOffset_GetValueAsync_ReturnsValue()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastModifiedAtOffset lastModifiedAtOffset)
+            return;
+
+        var value = await lastModifiedAtOffset.LastModifiedAtOffset.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(value);
+        Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAtOffset_GetValueAsync_ImmediateCancellation()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastModifiedAtOffset lastModifiedAtOffset)
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await lastModifiedAtOffset.LastModifiedAtOffset.GetValueAsync(cts.Token));
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAtOffset_Watcher_ReturnsNewInstanceEachCall()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastModifiedAtOffset { LastModifiedAtOffset: IMutableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        using var watcher1 = await prop.GetWatcherAsync(CancellationToken.None);
+        using var watcher2 = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreNotSame(watcher1, watcher2);
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAtOffset_Watcher_PropertyReferenceIsCorrect()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastModifiedAtOffset { LastModifiedAtOffset: IMutableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreSame(prop, watcher.Property);
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAtOffset_UpdateValueAsync_PersistsChange()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastModifiedAtOffset { LastModifiedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        var newValue = DateTimeOffset.Now.AddDays(-1);
+        await prop.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await prop.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(retrieved);
+        Assert.AreEqual(newValue.UtcDateTime.Year, retrieved.Value.UtcDateTime.Year);
+        Assert.AreEqual(newValue.UtcDateTime.Month, retrieved.Value.UtcDateTime.Month);
+        Assert.AreEqual(newValue.UtcDateTime.Day, retrieved.Value.UtcDateTime.Day);
+        Assert.AreEqual(newValue.UtcDateTime.Hour, retrieved.Value.UtcDateTime.Hour);
+        Assert.AreEqual(newValue.UtcDateTime.Minute, retrieved.Value.UtcDateTime.Minute);
+        Assert.AreEqual(newValue.UtcDateTime.Second, retrieved.Value.UtcDateTime.Second);
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAtOffset_UpdateValueAsync_NullThrows()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastModifiedAtOffset { LastModifiedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            await prop.UpdateValueAsync(null, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAtOffset_UpdateValueAsync_ImmediateCancellation()
+    {
+        var file = await CreateFileAsync();
+        if (file is not ILastModifiedAtOffset { LastModifiedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
+    }
+}

--- a/src/CommonIFileTests.cs
+++ b/src/CommonIFileTests.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace OwlCore.Storage.CommonTests
 {
-    public abstract class CommonIFileTests
+    public abstract partial class CommonIFileTests
     {
         /// <summary>
         /// Gets a boolean that indicates if the file support writing to the underlying stream.

--- a/src/CommonIFileTests.cs
+++ b/src/CommonIFileTests.cs
@@ -4,102 +4,163 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace OwlCore.Storage.CommonTests
+namespace OwlCore.Storage.CommonTests;
+
+public abstract partial class CommonIFileTests
 {
-    public abstract partial class CommonIFileTests
+    /// <summary>
+    /// Gets a boolean that indicates if the file support writing to the underlying stream.
+    /// </summary>
+    public virtual bool SupportsWriting => true;
+
+    /// <summary>
+    /// Gets the expected availability of the CreatedAt property value.
+    /// </summary>
+    public virtual PropertyValueAvailability CreatedAtAvailability => PropertyValueAvailability.Always;
+
+    /// <summary>
+    /// Gets the expected availability of the LastModifiedAt property value.
+    /// </summary>
+    public virtual PropertyValueAvailability LastModifiedAtAvailability => PropertyValueAvailability.Always;
+
+    /// <summary>
+    /// Gets the expected availability of the LastAccessedAt property value.
+    /// </summary>
+    public virtual PropertyValueAvailability LastAccessedAtAvailability => PropertyValueAvailability.Always;
+
+    /// <summary>
+    /// Gets the expected update behavior of the LastModifiedAt property.
+    /// </summary>
+    public virtual PropertyUpdateBehavior LastModifiedAtUpdateBehavior => PropertyUpdateBehavior.Immediate;
+
+    /// <summary>
+    /// Gets the expected update behavior of the LastAccessedAt property.
+    /// </summary>
+    public virtual PropertyUpdateBehavior LastAccessedAtUpdateBehavior => PropertyUpdateBehavior.Immediate;
+
+    /// <summary>
+    /// Gets the expected update behavior of the CreatedAt property.
+    /// </summary>
+    public virtual PropertyUpdateBehavior CreatedAtUpdateBehavior => PropertyUpdateBehavior.Immediate;
+
+    /// <summary>
+    /// Call the constructor using valid input parameters.
+    /// </summary>
+    public abstract Task<IFile> CreateFileAsync();
+
+    /// <summary>
+    /// Creates a file with a specific CreatedAt timestamp.
+    /// </summary>
+    /// <param name="createdAt">The creation timestamp to apply.</param>
+    /// <returns>The created file, or null if the implementation doesn't support setting CreatedAt.</returns>
+    /// <remarks>
+    /// Implementations must explicitly return null if they don't support setting CreatedAt,
+    /// which signals the test should be skipped. This ensures gaps are surfaced rather than silently ignored.
+    /// </remarks>
+    public abstract Task<IFile?> CreateFileWithCreatedAtAsync(DateTime createdAt);
+
+    /// <summary>
+    /// Creates a file with a specific LastModifiedAt timestamp.
+    /// </summary>
+    /// <param name="lastModifiedAt">The last modified timestamp to apply.</param>
+    /// <returns>The created file, or null if the implementation doesn't support setting LastModifiedAt.</returns>
+    /// <remarks>
+    /// Implementations must explicitly return null if they don't support setting LastModifiedAt,
+    /// which signals the test should be skipped. This ensures gaps are surfaced rather than silently ignored.
+    /// </remarks>
+    public abstract Task<IFile?> CreateFileWithLastModifiedAtAsync(DateTime lastModifiedAt);
+
+    /// <summary>
+    /// Creates a file with a specific LastAccessedAt timestamp.
+    /// </summary>
+    /// <param name="lastAccessedAt">The last accessed timestamp to apply.</param>
+    /// <returns>The created file, or null if the implementation doesn't support setting LastAccessedAt.</returns>
+    /// <remarks>
+    /// Implementations must explicitly return null if they don't support setting LastAccessedAt,
+    /// which signals the test should be skipped. This ensures gaps are surfaced rather than silently ignored.
+    /// </remarks>
+    public abstract Task<IFile?> CreateFileWithLastAccessedAtAsync(DateTime lastAccessedAt);
+
+    [TestMethod]
+    public Task ConstructorCall_ValidParameters()
     {
-        /// <summary>
-        /// Gets a boolean that indicates if the file support writing to the underlying stream.
-        /// </summary>
-        public virtual bool SupportsWriting => true;
+        // Shouldn't throw when constructor is called.
+        return CreateFileAsync();
+    }
 
-        /// <summary>
-        /// Call the constructor using valid input parameters.
-        /// </summary>
-        public abstract Task<IFile> CreateFileAsync();
+    [TestMethod]
+    public async Task IdNotNullOrWhiteSpace()
+    {
+        var file = await CreateFileAsync();
 
-        [TestMethod]
-        public Task ConstructorCall_ValidParameters()
+        Assert.IsFalse(string.IsNullOrWhiteSpace(file.Id));
+    }
+
+    [TestMethod]
+    [AllEnumFlagCombinations(typeof(FileAccess))]
+    public async Task OpenStreamAndTryEachAccessMode(FileAccess accessMode)
+    {
+        var file = await CreateFileAsync();
+
+        if (accessMode == 0)
         {
-            // Shouldn't throw when constructor is called.
-            return CreateFileAsync();
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => file.OpenStreamAsync(accessMode));
+            return;
         }
 
-        [TestMethod]
-        public async Task IdNotNullOrWhiteSpace()
-        {
-            var file = await CreateFileAsync();
+        // Don't test writing if not supported - remove the Write flag using AND NOT.
+        if (!SupportsWriting)
+            accessMode &= ~FileAccess.Write;
 
-            Assert.IsFalse(string.IsNullOrWhiteSpace(file.Id));
+        // If removing write access resulted in empty flag.
+        if (accessMode == 0)
+            return;
+
+        using var stream = await file.OpenStreamAsync(accessMode);
+
+        if (accessMode.HasFlag(FileAccess.Read))
+        {
+            using var memoryStream = new MemoryStream();
+            await stream.CopyToAsync(memoryStream);
+
+            Assert.AreNotEqual(0, memoryStream.ToArray().Length);
         }
 
-        [TestMethod]
-        [AllEnumFlagCombinations(typeof(FileAccess))]
-        public async Task OpenStreamAndTryEachAccessMode(FileAccess accessMode)
+        if (accessMode.HasFlag(FileAccess.Write) && SupportsWriting)
         {
-            var file = await CreateFileAsync();
-
-            if (accessMode == 0)
-            {
-                await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => file.OpenStreamAsync(accessMode));
-                return;
-            }
-
-            // Don't test writing if not supported.
-            if (!SupportsWriting)
-                accessMode ^= FileAccess.Write;
-
-            // If removing write access resulted in empty flag.
-            if (accessMode == 0)
-                return;
-
-            using var stream = await file.OpenStreamAsync(accessMode);
-
-            if (accessMode.HasFlag(FileAccess.Read))
-            {
-                using var memoryStream = new MemoryStream();
-                await stream.CopyToAsync(memoryStream);
-
-                Assert.AreNotEqual(0, memoryStream.ToArray().Length);
-            }
-
-            if (accessMode.HasFlag(FileAccess.Write) && SupportsWriting)
-            {
-                stream.WriteByte(0);
-            }
-        }
-
-        [TestMethod]
-        [AllEnumFlagCombinations(typeof(FileAccess))]
-        public async Task OpenStreamWithEachAccessModeAndCancelToken(FileAccess accessMode)
-        {
-            var cancellationTokenSource = new CancellationTokenSource();
-
-            var file = await CreateFileAsync();
-
-            if (accessMode == 0)
-            {
-                var task = Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => file.OpenStreamAsync(accessMode, cancellationTokenSource.Token));
-                cancellationTokenSource.Cancel();
-
-                await task;
-                return;
-            }
-
-            cancellationTokenSource.Cancel();
-
-            await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            {
-                try
-                {
-                    await file.OpenStreamAsync(accessMode, cancellationTokenSource.Token);
-                }
-                catch (TaskCanceledException e)
-                {
-                    throw new OperationCanceledException(e.Message);
-                }
-            });
+            stream.WriteByte(0);
         }
     }
 
+    [TestMethod]
+    [AllEnumFlagCombinations(typeof(FileAccess))]
+    public async Task OpenStreamWithEachAccessModeAndCancelToken(FileAccess accessMode)
+    {
+        var cancellationTokenSource = new CancellationTokenSource();
+
+        var file = await CreateFileAsync();
+
+        if (accessMode == 0)
+        {
+            var task = Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => file.OpenStreamAsync(accessMode, cancellationTokenSource.Token));
+            cancellationTokenSource.Cancel();
+
+            await task;
+            return;
+        }
+
+        cancellationTokenSource.Cancel();
+
+        await AssertEx.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+        {
+            try
+            {
+                await file.OpenStreamAsync(accessMode, cancellationTokenSource.Token);
+            }
+            catch (TaskCanceledException e)
+            {
+                throw new OperationCanceledException(e.Message);
+            }
+        });
+    }
 }

--- a/src/CommonIFolderTests.CreatedAt.cs
+++ b/src/CommonIFolderTests.CreatedAt.cs
@@ -39,8 +39,8 @@ public abstract partial class CommonIFolderTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await createdAt.CreatedAt.GetValueAsync(cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            createdAt.CreatedAt.GetValueAsync(cts.Token));
     }
 
     [TestMethod]
@@ -109,7 +109,7 @@ public abstract partial class CommonIFolderTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await prop.UpdateValueAsync(DateTime.Now, cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            prop.UpdateValueAsync(DateTime.Now, cts.Token));
     }
 }

--- a/src/CommonIFolderTests.CreatedAt.cs
+++ b/src/CommonIFolderTests.CreatedAt.cs
@@ -25,8 +25,43 @@ public abstract partial class CommonIFolderTests
             return;
 
         var value = await createdAt.CreatedAt.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(value);
-        Assert.AreNotEqual(DateTime.MinValue, value.Value);
+
+        switch (CreatedAtAvailability)
+        {
+            case PropertyValueAvailability.Always:
+                Assert.IsNotNull(value, "CreatedAt should always have a value for this implementation.");
+                Assert.AreNotEqual(DateTime.MinValue, value.Value);
+                break;
+
+            case PropertyValueAvailability.Maybe:
+                if (value is not null)
+                    Assert.AreNotEqual(DateTime.MinValue, value.Value);
+                break;
+        }
+    }
+
+    [TestMethod]
+    public async Task CreatedAt_CreateWithKnownTimestamp_ReturnsCorrectValue()
+    {
+        var expectedTimestamp = DateTime.UtcNow.AddDays(-30);
+        var folder = await CreateFolderWithCreatedAtAsync(expectedTimestamp);
+        
+        // Skip if implementation doesn't support creating folders with known timestamps
+        if (folder is null)
+            return;
+
+        if (folder is not ICreatedAt createdAt)
+        {
+            Assert.Fail("CreateFolderWithCreatedAtAsync returned a folder that doesn't implement ICreatedAt.");
+            return;
+        }
+
+        var value = await createdAt.CreatedAt.GetValueAsync(CancellationToken.None);
+        
+        Assert.IsNotNull(value, "CreatedAt should have a value when created with a known timestamp.");
+        
+        var diff = Math.Abs((value.Value.ToUniversalTime() - expectedTimestamp).TotalSeconds);
+        Assert.IsTrue(diff < 2, $"CreatedAt should match the requested timestamp. Expected={expectedTimestamp:O}, Actual={value:O}, Diff={diff:F2}s");
     }
 
     [TestMethod]
@@ -66,50 +101,5 @@ public abstract partial class CommonIFolderTests
         using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
 
         Assert.AreSame(prop, watcher.Property);
-    }
-
-    [TestMethod]
-    public async Task CreatedAt_UpdateValueAsync_PersistsChange()
-    {
-        var folder = await CreateFolderAsync();
-        if (folder is not ICreatedAt { CreatedAt: IModifiableStorageProperty<DateTime?> prop })
-            return;
-
-        var newValue = DateTime.Now.AddDays(-1);
-        await prop.UpdateValueAsync(newValue, CancellationToken.None);
-
-        var retrieved = await prop.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(retrieved);
-        Assert.AreEqual(newValue.Year, retrieved.Value.Year);
-        Assert.AreEqual(newValue.Month, retrieved.Value.Month);
-        Assert.AreEqual(newValue.Day, retrieved.Value.Day);
-        Assert.AreEqual(newValue.Hour, retrieved.Value.Hour);
-        Assert.AreEqual(newValue.Minute, retrieved.Value.Minute);
-        Assert.AreEqual(newValue.Second, retrieved.Value.Second);
-    }
-
-    [TestMethod]
-    public async Task CreatedAt_UpdateValueAsync_NullThrows()
-    {
-        var folder = await CreateFolderAsync();
-        if (folder is not ICreatedAt { CreatedAt: IModifiableStorageProperty<DateTime?> prop })
-            return;
-
-        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
-            await prop.UpdateValueAsync(null, CancellationToken.None));
-    }
-
-    [TestMethod]
-    public async Task CreatedAt_UpdateValueAsync_ImmediateCancellation()
-    {
-        var folder = await CreateFolderAsync();
-        if (folder is not ICreatedAt { CreatedAt: IModifiableStorageProperty<DateTime?> prop })
-            return;
-
-        var cts = new CancellationTokenSource();
-        cts.Cancel();
-
-        Assert.ThrowsException<OperationCanceledException>(() =>
-            prop.UpdateValueAsync(DateTime.Now, cts.Token));
     }
 }

--- a/src/CommonIFolderTests.CreatedAt.cs
+++ b/src/CommonIFolderTests.CreatedAt.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace OwlCore.Storage.CommonTests;
+
+public abstract partial class CommonIFolderTests
+{
+    [TestMethod]
+    public async Task CreatedAt_PropertyName_MatchesInterfaceMember()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ICreatedAt createdAt)
+            return;
+
+        Assert.AreEqual(nameof(ICreatedAt.CreatedAt), createdAt.CreatedAt.Name);
+    }
+
+    [TestMethod]
+    public async Task CreatedAt_GetValueAsync_ReturnsValue()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ICreatedAt createdAt)
+            return;
+
+        var value = await createdAt.CreatedAt.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(value);
+        Assert.AreNotEqual(DateTime.MinValue, value.Value);
+    }
+
+    [TestMethod]
+    public async Task CreatedAt_GetValueAsync_ImmediateCancellation()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ICreatedAt createdAt)
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await createdAt.CreatedAt.GetValueAsync(cts.Token));
+    }
+
+    [TestMethod]
+    public async Task CreatedAt_Watcher_ReturnsNewInstanceEachCall()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ICreatedAt { CreatedAt: IMutableStorageProperty<DateTime?> prop })
+            return;
+
+        using var watcher1 = await prop.GetWatcherAsync(CancellationToken.None);
+        using var watcher2 = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreNotSame(watcher1, watcher2);
+    }
+
+    [TestMethod]
+    public async Task CreatedAt_Watcher_PropertyReferenceIsCorrect()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ICreatedAt { CreatedAt: IMutableStorageProperty<DateTime?> prop })
+            return;
+
+        using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreSame(prop, watcher.Property);
+    }
+
+    [TestMethod]
+    public async Task CreatedAt_UpdateValueAsync_PersistsChange()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ICreatedAt { CreatedAt: IModifiableStorageProperty<DateTime?> prop })
+            return;
+
+        var newValue = DateTime.Now.AddDays(-1);
+        await prop.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await prop.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(retrieved);
+        Assert.AreEqual(newValue.Year, retrieved.Value.Year);
+        Assert.AreEqual(newValue.Month, retrieved.Value.Month);
+        Assert.AreEqual(newValue.Day, retrieved.Value.Day);
+        Assert.AreEqual(newValue.Hour, retrieved.Value.Hour);
+        Assert.AreEqual(newValue.Minute, retrieved.Value.Minute);
+        Assert.AreEqual(newValue.Second, retrieved.Value.Second);
+    }
+
+    [TestMethod]
+    public async Task CreatedAt_UpdateValueAsync_NullThrows()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ICreatedAt { CreatedAt: IModifiableStorageProperty<DateTime?> prop })
+            return;
+
+        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            await prop.UpdateValueAsync(null, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task CreatedAt_UpdateValueAsync_ImmediateCancellation()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ICreatedAt { CreatedAt: IModifiableStorageProperty<DateTime?> prop })
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await prop.UpdateValueAsync(DateTime.Now, cts.Token));
+    }
+}

--- a/src/CommonIFolderTests.CreatedAtOffset.cs
+++ b/src/CommonIFolderTests.CreatedAtOffset.cs
@@ -39,8 +39,8 @@ public abstract partial class CommonIFolderTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await createdAtOffset.CreatedAtOffset.GetValueAsync(cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            createdAtOffset.CreatedAtOffset.GetValueAsync(cts.Token));
     }
 
     [TestMethod]
@@ -109,7 +109,7 @@ public abstract partial class CommonIFolderTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
     }
 }

--- a/src/CommonIFolderTests.CreatedAtOffset.cs
+++ b/src/CommonIFolderTests.CreatedAtOffset.cs
@@ -25,8 +25,19 @@ public abstract partial class CommonIFolderTests
             return;
 
         var value = await createdAtOffset.CreatedAtOffset.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(value);
-        Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+
+        switch (CreatedAtAvailability)
+        {
+            case PropertyValueAvailability.Always:
+                Assert.IsNotNull(value, "CreatedAtOffset should always have a value for this implementation.");
+                Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+                break;
+
+            case PropertyValueAvailability.Maybe:
+                if (value is not null)
+                    Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+                break;
+        }
     }
 
     [TestMethod]
@@ -66,50 +77,5 @@ public abstract partial class CommonIFolderTests
         using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
 
         Assert.AreSame(prop, watcher.Property);
-    }
-
-    [TestMethod]
-    public async Task CreatedAtOffset_UpdateValueAsync_PersistsChange()
-    {
-        var folder = await CreateFolderAsync();
-        if (folder is not ICreatedAtOffset { CreatedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
-            return;
-
-        var newValue = DateTimeOffset.Now.AddDays(-1);
-        await prop.UpdateValueAsync(newValue, CancellationToken.None);
-
-        var retrieved = await prop.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(retrieved);
-        Assert.AreEqual(newValue.UtcDateTime.Year, retrieved.Value.UtcDateTime.Year);
-        Assert.AreEqual(newValue.UtcDateTime.Month, retrieved.Value.UtcDateTime.Month);
-        Assert.AreEqual(newValue.UtcDateTime.Day, retrieved.Value.UtcDateTime.Day);
-        Assert.AreEqual(newValue.UtcDateTime.Hour, retrieved.Value.UtcDateTime.Hour);
-        Assert.AreEqual(newValue.UtcDateTime.Minute, retrieved.Value.UtcDateTime.Minute);
-        Assert.AreEqual(newValue.UtcDateTime.Second, retrieved.Value.UtcDateTime.Second);
-    }
-
-    [TestMethod]
-    public async Task CreatedAtOffset_UpdateValueAsync_NullThrows()
-    {
-        var folder = await CreateFolderAsync();
-        if (folder is not ICreatedAtOffset { CreatedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
-            return;
-
-        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
-            await prop.UpdateValueAsync(null, CancellationToken.None));
-    }
-
-    [TestMethod]
-    public async Task CreatedAtOffset_UpdateValueAsync_ImmediateCancellation()
-    {
-        var folder = await CreateFolderAsync();
-        if (folder is not ICreatedAtOffset { CreatedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
-            return;
-
-        var cts = new CancellationTokenSource();
-        cts.Cancel();
-
-        Assert.ThrowsException<OperationCanceledException>(() =>
-            prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
     }
 }

--- a/src/CommonIFolderTests.CreatedAtOffset.cs
+++ b/src/CommonIFolderTests.CreatedAtOffset.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace OwlCore.Storage.CommonTests;
+
+public abstract partial class CommonIFolderTests
+{
+    [TestMethod]
+    public async Task CreatedAtOffset_PropertyName_MatchesInterfaceMember()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ICreatedAtOffset createdAtOffset)
+            return;
+
+        Assert.AreEqual(nameof(ICreatedAtOffset.CreatedAtOffset), createdAtOffset.CreatedAtOffset.Name);
+    }
+
+    [TestMethod]
+    public async Task CreatedAtOffset_GetValueAsync_ReturnsValue()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ICreatedAtOffset createdAtOffset)
+            return;
+
+        var value = await createdAtOffset.CreatedAtOffset.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(value);
+        Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+    }
+
+    [TestMethod]
+    public async Task CreatedAtOffset_GetValueAsync_ImmediateCancellation()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ICreatedAtOffset createdAtOffset)
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await createdAtOffset.CreatedAtOffset.GetValueAsync(cts.Token));
+    }
+
+    [TestMethod]
+    public async Task CreatedAtOffset_Watcher_ReturnsNewInstanceEachCall()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ICreatedAtOffset { CreatedAtOffset: IMutableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        using var watcher1 = await prop.GetWatcherAsync(CancellationToken.None);
+        using var watcher2 = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreNotSame(watcher1, watcher2);
+    }
+
+    [TestMethod]
+    public async Task CreatedAtOffset_Watcher_PropertyReferenceIsCorrect()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ICreatedAtOffset { CreatedAtOffset: IMutableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreSame(prop, watcher.Property);
+    }
+
+    [TestMethod]
+    public async Task CreatedAtOffset_UpdateValueAsync_PersistsChange()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ICreatedAtOffset { CreatedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        var newValue = DateTimeOffset.Now.AddDays(-1);
+        await prop.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await prop.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(retrieved);
+        Assert.AreEqual(newValue.UtcDateTime.Year, retrieved.Value.UtcDateTime.Year);
+        Assert.AreEqual(newValue.UtcDateTime.Month, retrieved.Value.UtcDateTime.Month);
+        Assert.AreEqual(newValue.UtcDateTime.Day, retrieved.Value.UtcDateTime.Day);
+        Assert.AreEqual(newValue.UtcDateTime.Hour, retrieved.Value.UtcDateTime.Hour);
+        Assert.AreEqual(newValue.UtcDateTime.Minute, retrieved.Value.UtcDateTime.Minute);
+        Assert.AreEqual(newValue.UtcDateTime.Second, retrieved.Value.UtcDateTime.Second);
+    }
+
+    [TestMethod]
+    public async Task CreatedAtOffset_UpdateValueAsync_NullThrows()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ICreatedAtOffset { CreatedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            await prop.UpdateValueAsync(null, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task CreatedAtOffset_UpdateValueAsync_ImmediateCancellation()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ICreatedAtOffset { CreatedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
+    }
+}

--- a/src/CommonIFolderTests.LastAccessedAt.cs
+++ b/src/CommonIFolderTests.LastAccessedAt.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace OwlCore.Storage.CommonTests;
+
+public abstract partial class CommonIFolderTests
+{
+    [TestMethod]
+    public async Task LastAccessedAt_PropertyName_MatchesInterfaceMember()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastAccessedAt lastAccessedAt)
+            return;
+
+        Assert.AreEqual(nameof(ILastAccessedAt.LastAccessedAt), lastAccessedAt.LastAccessedAt.Name);
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAt_GetValueAsync_ReturnsValue()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastAccessedAt lastAccessedAt)
+            return;
+
+        var value = await lastAccessedAt.LastAccessedAt.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(value);
+        Assert.AreNotEqual(DateTime.MinValue, value.Value);
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAt_GetValueAsync_ImmediateCancellation()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastAccessedAt lastAccessedAt)
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await lastAccessedAt.LastAccessedAt.GetValueAsync(cts.Token));
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAt_Watcher_ReturnsNewInstanceEachCall()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastAccessedAt { LastAccessedAt: IMutableStorageProperty<DateTime?> prop })
+            return;
+
+        using var watcher1 = await prop.GetWatcherAsync(CancellationToken.None);
+        using var watcher2 = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreNotSame(watcher1, watcher2);
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAt_Watcher_PropertyReferenceIsCorrect()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastAccessedAt { LastAccessedAt: IMutableStorageProperty<DateTime?> prop })
+            return;
+
+        using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreSame(prop, watcher.Property);
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAt_UpdateValueAsync_PersistsChange()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastAccessedAt { LastAccessedAt: IModifiableStorageProperty<DateTime?> prop })
+            return;
+
+        var newValue = DateTime.Now.AddDays(-1);
+        await prop.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await prop.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(retrieved);
+        Assert.AreEqual(newValue.Year, retrieved.Value.Year);
+        Assert.AreEqual(newValue.Month, retrieved.Value.Month);
+        Assert.AreEqual(newValue.Day, retrieved.Value.Day);
+        Assert.AreEqual(newValue.Hour, retrieved.Value.Hour);
+        Assert.AreEqual(newValue.Minute, retrieved.Value.Minute);
+        Assert.AreEqual(newValue.Second, retrieved.Value.Second);
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAt_UpdateValueAsync_NullThrows()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastAccessedAt { LastAccessedAt: IModifiableStorageProperty<DateTime?> prop })
+            return;
+
+        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            await prop.UpdateValueAsync(null, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAt_UpdateValueAsync_ImmediateCancellation()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastAccessedAt { LastAccessedAt: IModifiableStorageProperty<DateTime?> prop })
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await prop.UpdateValueAsync(DateTime.Now, cts.Token));
+    }
+}

--- a/src/CommonIFolderTests.LastAccessedAt.cs
+++ b/src/CommonIFolderTests.LastAccessedAt.cs
@@ -39,8 +39,8 @@ public abstract partial class CommonIFolderTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await lastAccessedAt.LastAccessedAt.GetValueAsync(cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            lastAccessedAt.LastAccessedAt.GetValueAsync(cts.Token));
     }
 
     [TestMethod]
@@ -109,7 +109,7 @@ public abstract partial class CommonIFolderTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await prop.UpdateValueAsync(DateTime.Now, cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            prop.UpdateValueAsync(DateTime.Now, cts.Token));
     }
 }

--- a/src/CommonIFolderTests.LastAccessedAt.cs
+++ b/src/CommonIFolderTests.LastAccessedAt.cs
@@ -25,8 +25,43 @@ public abstract partial class CommonIFolderTests
             return;
 
         var value = await lastAccessedAt.LastAccessedAt.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(value);
-        Assert.AreNotEqual(DateTime.MinValue, value.Value);
+
+        switch (LastAccessedAtAvailability)
+        {
+            case PropertyValueAvailability.Always:
+                Assert.IsNotNull(value, "LastAccessedAt should always have a value for this implementation.");
+                Assert.AreNotEqual(DateTime.MinValue, value.Value);
+                break;
+
+            case PropertyValueAvailability.Maybe:
+                if (value is not null)
+                    Assert.AreNotEqual(DateTime.MinValue, value.Value);
+                break;
+        }
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAt_CreateWithKnownTimestamp_ReturnsCorrectValue()
+    {
+        var expectedTimestamp = DateTime.UtcNow.AddDays(-7);
+        var folder = await CreateFolderWithLastAccessedAtAsync(expectedTimestamp);
+        
+        // Skip if implementation doesn't support creating folders with known timestamps
+        if (folder is null)
+            return;
+
+        if (folder is not ILastAccessedAt lastAccessedAt)
+        {
+            Assert.Fail("CreateFolderWithLastAccessedAtAsync returned a folder that doesn't implement ILastAccessedAt.");
+            return;
+        }
+
+        var value = await lastAccessedAt.LastAccessedAt.GetValueAsync(CancellationToken.None);
+        
+        Assert.IsNotNull(value, "LastAccessedAt should have a value when created with a known timestamp.");
+        
+        var diff = Math.Abs((value.Value.ToUniversalTime() - expectedTimestamp).TotalSeconds);
+        Assert.IsTrue(diff < 2, $"LastAccessedAt should match the requested timestamp. Expected={expectedTimestamp:O}, Actual={value:O}, Diff={diff:F2}s");
     }
 
     [TestMethod]
@@ -66,50 +101,5 @@ public abstract partial class CommonIFolderTests
         using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
 
         Assert.AreSame(prop, watcher.Property);
-    }
-
-    [TestMethod]
-    public async Task LastAccessedAt_UpdateValueAsync_PersistsChange()
-    {
-        var folder = await CreateFolderAsync();
-        if (folder is not ILastAccessedAt { LastAccessedAt: IModifiableStorageProperty<DateTime?> prop })
-            return;
-
-        var newValue = DateTime.Now.AddDays(-1);
-        await prop.UpdateValueAsync(newValue, CancellationToken.None);
-
-        var retrieved = await prop.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(retrieved);
-        Assert.AreEqual(newValue.Year, retrieved.Value.Year);
-        Assert.AreEqual(newValue.Month, retrieved.Value.Month);
-        Assert.AreEqual(newValue.Day, retrieved.Value.Day);
-        Assert.AreEqual(newValue.Hour, retrieved.Value.Hour);
-        Assert.AreEqual(newValue.Minute, retrieved.Value.Minute);
-        Assert.AreEqual(newValue.Second, retrieved.Value.Second);
-    }
-
-    [TestMethod]
-    public async Task LastAccessedAt_UpdateValueAsync_NullThrows()
-    {
-        var folder = await CreateFolderAsync();
-        if (folder is not ILastAccessedAt { LastAccessedAt: IModifiableStorageProperty<DateTime?> prop })
-            return;
-
-        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
-            await prop.UpdateValueAsync(null, CancellationToken.None));
-    }
-
-    [TestMethod]
-    public async Task LastAccessedAt_UpdateValueAsync_ImmediateCancellation()
-    {
-        var folder = await CreateFolderAsync();
-        if (folder is not ILastAccessedAt { LastAccessedAt: IModifiableStorageProperty<DateTime?> prop })
-            return;
-
-        var cts = new CancellationTokenSource();
-        cts.Cancel();
-
-        Assert.ThrowsException<OperationCanceledException>(() =>
-            prop.UpdateValueAsync(DateTime.Now, cts.Token));
     }
 }

--- a/src/CommonIFolderTests.LastAccessedAtOffset.cs
+++ b/src/CommonIFolderTests.LastAccessedAtOffset.cs
@@ -39,8 +39,8 @@ public abstract partial class CommonIFolderTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await lastAccessedAtOffset.LastAccessedAtOffset.GetValueAsync(cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            lastAccessedAtOffset.LastAccessedAtOffset.GetValueAsync(cts.Token));
     }
 
     [TestMethod]
@@ -109,7 +109,7 @@ public abstract partial class CommonIFolderTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
     }
 }

--- a/src/CommonIFolderTests.LastAccessedAtOffset.cs
+++ b/src/CommonIFolderTests.LastAccessedAtOffset.cs
@@ -25,8 +25,19 @@ public abstract partial class CommonIFolderTests
             return;
 
         var value = await lastAccessedAtOffset.LastAccessedAtOffset.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(value);
-        Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+
+        switch (LastAccessedAtAvailability)
+        {
+            case PropertyValueAvailability.Always:
+                Assert.IsNotNull(value, "LastAccessedAtOffset should always have a value for this implementation.");
+                Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+                break;
+
+            case PropertyValueAvailability.Maybe:
+                if (value is not null)
+                    Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+                break;
+        }
     }
 
     [TestMethod]
@@ -66,50 +77,5 @@ public abstract partial class CommonIFolderTests
         using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
 
         Assert.AreSame(prop, watcher.Property);
-    }
-
-    [TestMethod]
-    public async Task LastAccessedAtOffset_UpdateValueAsync_PersistsChange()
-    {
-        var folder = await CreateFolderAsync();
-        if (folder is not ILastAccessedAtOffset { LastAccessedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
-            return;
-
-        var newValue = DateTimeOffset.Now.AddDays(-1);
-        await prop.UpdateValueAsync(newValue, CancellationToken.None);
-
-        var retrieved = await prop.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(retrieved);
-        Assert.AreEqual(newValue.UtcDateTime.Year, retrieved.Value.UtcDateTime.Year);
-        Assert.AreEqual(newValue.UtcDateTime.Month, retrieved.Value.UtcDateTime.Month);
-        Assert.AreEqual(newValue.UtcDateTime.Day, retrieved.Value.UtcDateTime.Day);
-        Assert.AreEqual(newValue.UtcDateTime.Hour, retrieved.Value.UtcDateTime.Hour);
-        Assert.AreEqual(newValue.UtcDateTime.Minute, retrieved.Value.UtcDateTime.Minute);
-        Assert.AreEqual(newValue.UtcDateTime.Second, retrieved.Value.UtcDateTime.Second);
-    }
-
-    [TestMethod]
-    public async Task LastAccessedAtOffset_UpdateValueAsync_NullThrows()
-    {
-        var folder = await CreateFolderAsync();
-        if (folder is not ILastAccessedAtOffset { LastAccessedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
-            return;
-
-        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
-            await prop.UpdateValueAsync(null, CancellationToken.None));
-    }
-
-    [TestMethod]
-    public async Task LastAccessedAtOffset_UpdateValueAsync_ImmediateCancellation()
-    {
-        var folder = await CreateFolderAsync();
-        if (folder is not ILastAccessedAtOffset { LastAccessedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
-            return;
-
-        var cts = new CancellationTokenSource();
-        cts.Cancel();
-
-        Assert.ThrowsException<OperationCanceledException>(() =>
-            prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
     }
 }

--- a/src/CommonIFolderTests.LastAccessedAtOffset.cs
+++ b/src/CommonIFolderTests.LastAccessedAtOffset.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace OwlCore.Storage.CommonTests;
+
+public abstract partial class CommonIFolderTests
+{
+    [TestMethod]
+    public async Task LastAccessedAtOffset_PropertyName_MatchesInterfaceMember()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastAccessedAtOffset lastAccessedAtOffset)
+            return;
+
+        Assert.AreEqual(nameof(ILastAccessedAtOffset.LastAccessedAtOffset), lastAccessedAtOffset.LastAccessedAtOffset.Name);
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAtOffset_GetValueAsync_ReturnsValue()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastAccessedAtOffset lastAccessedAtOffset)
+            return;
+
+        var value = await lastAccessedAtOffset.LastAccessedAtOffset.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(value);
+        Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAtOffset_GetValueAsync_ImmediateCancellation()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastAccessedAtOffset lastAccessedAtOffset)
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await lastAccessedAtOffset.LastAccessedAtOffset.GetValueAsync(cts.Token));
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAtOffset_Watcher_ReturnsNewInstanceEachCall()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastAccessedAtOffset { LastAccessedAtOffset: IMutableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        using var watcher1 = await prop.GetWatcherAsync(CancellationToken.None);
+        using var watcher2 = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreNotSame(watcher1, watcher2);
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAtOffset_Watcher_PropertyReferenceIsCorrect()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastAccessedAtOffset { LastAccessedAtOffset: IMutableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreSame(prop, watcher.Property);
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAtOffset_UpdateValueAsync_PersistsChange()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastAccessedAtOffset { LastAccessedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        var newValue = DateTimeOffset.Now.AddDays(-1);
+        await prop.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await prop.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(retrieved);
+        Assert.AreEqual(newValue.UtcDateTime.Year, retrieved.Value.UtcDateTime.Year);
+        Assert.AreEqual(newValue.UtcDateTime.Month, retrieved.Value.UtcDateTime.Month);
+        Assert.AreEqual(newValue.UtcDateTime.Day, retrieved.Value.UtcDateTime.Day);
+        Assert.AreEqual(newValue.UtcDateTime.Hour, retrieved.Value.UtcDateTime.Hour);
+        Assert.AreEqual(newValue.UtcDateTime.Minute, retrieved.Value.UtcDateTime.Minute);
+        Assert.AreEqual(newValue.UtcDateTime.Second, retrieved.Value.UtcDateTime.Second);
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAtOffset_UpdateValueAsync_NullThrows()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastAccessedAtOffset { LastAccessedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            await prop.UpdateValueAsync(null, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task LastAccessedAtOffset_UpdateValueAsync_ImmediateCancellation()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastAccessedAtOffset { LastAccessedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
+    }
+}

--- a/src/CommonIFolderTests.LastModifiedAt.cs
+++ b/src/CommonIFolderTests.LastModifiedAt.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace OwlCore.Storage.CommonTests;
+
+public abstract partial class CommonIFolderTests
+{
+    [TestMethod]
+    public async Task LastModifiedAt_PropertyName_MatchesInterfaceMember()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastModifiedAt lastModifiedAt)
+            return;
+
+        Assert.AreEqual(nameof(ILastModifiedAt.LastModifiedAt), lastModifiedAt.LastModifiedAt.Name);
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAt_GetValueAsync_ReturnsValue()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastModifiedAt lastModifiedAt)
+            return;
+
+        var value = await lastModifiedAt.LastModifiedAt.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(value);
+        Assert.AreNotEqual(DateTime.MinValue, value.Value);
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAt_GetValueAsync_ImmediateCancellation()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastModifiedAt lastModifiedAt)
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await lastModifiedAt.LastModifiedAt.GetValueAsync(cts.Token));
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAt_Watcher_ReturnsNewInstanceEachCall()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastModifiedAt { LastModifiedAt: IMutableStorageProperty<DateTime?> prop })
+            return;
+
+        using var watcher1 = await prop.GetWatcherAsync(CancellationToken.None);
+        using var watcher2 = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreNotSame(watcher1, watcher2);
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAt_Watcher_PropertyReferenceIsCorrect()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastModifiedAt { LastModifiedAt: IMutableStorageProperty<DateTime?> prop })
+            return;
+
+        using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreSame(prop, watcher.Property);
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAt_UpdateValueAsync_PersistsChange()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastModifiedAt { LastModifiedAt: IModifiableStorageProperty<DateTime?> prop })
+            return;
+
+        var newValue = DateTime.Now.AddDays(-1);
+        await prop.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await prop.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(retrieved);
+        Assert.AreEqual(newValue.Year, retrieved.Value.Year);
+        Assert.AreEqual(newValue.Month, retrieved.Value.Month);
+        Assert.AreEqual(newValue.Day, retrieved.Value.Day);
+        Assert.AreEqual(newValue.Hour, retrieved.Value.Hour);
+        Assert.AreEqual(newValue.Minute, retrieved.Value.Minute);
+        Assert.AreEqual(newValue.Second, retrieved.Value.Second);
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAt_UpdateValueAsync_NullThrows()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastModifiedAt { LastModifiedAt: IModifiableStorageProperty<DateTime?> prop })
+            return;
+
+        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            await prop.UpdateValueAsync(null, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAt_UpdateValueAsync_ImmediateCancellation()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastModifiedAt { LastModifiedAt: IModifiableStorageProperty<DateTime?> prop })
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await prop.UpdateValueAsync(DateTime.Now, cts.Token));
+    }
+}

--- a/src/CommonIFolderTests.LastModifiedAt.cs
+++ b/src/CommonIFolderTests.LastModifiedAt.cs
@@ -39,8 +39,8 @@ public abstract partial class CommonIFolderTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await lastModifiedAt.LastModifiedAt.GetValueAsync(cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            lastModifiedAt.LastModifiedAt.GetValueAsync(cts.Token));
     }
 
     [TestMethod]
@@ -109,7 +109,7 @@ public abstract partial class CommonIFolderTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await prop.UpdateValueAsync(DateTime.Now, cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            prop.UpdateValueAsync(DateTime.Now, cts.Token));
     }
 }

--- a/src/CommonIFolderTests.LastModifiedAt.cs
+++ b/src/CommonIFolderTests.LastModifiedAt.cs
@@ -25,8 +25,43 @@ public abstract partial class CommonIFolderTests
             return;
 
         var value = await lastModifiedAt.LastModifiedAt.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(value);
-        Assert.AreNotEqual(DateTime.MinValue, value.Value);
+
+        switch (LastModifiedAtAvailability)
+        {
+            case PropertyValueAvailability.Always:
+                Assert.IsNotNull(value, "LastModifiedAt should always have a value for this implementation.");
+                Assert.AreNotEqual(DateTime.MinValue, value.Value);
+                break;
+
+            case PropertyValueAvailability.Maybe:
+                if (value is not null)
+                    Assert.AreNotEqual(DateTime.MinValue, value.Value);
+                break;
+        }
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAt_CreateWithKnownTimestamp_ReturnsCorrectValue()
+    {
+        var expectedTimestamp = DateTime.UtcNow.AddDays(-15);
+        var folder = await CreateFolderWithLastModifiedAtAsync(expectedTimestamp);
+        
+        // Skip if implementation doesn't support creating folders with known timestamps
+        if (folder is null)
+            return;
+
+        if (folder is not ILastModifiedAt lastModifiedAt)
+        {
+            Assert.Fail("CreateFolderWithLastModifiedAtAsync returned a folder that doesn't implement ILastModifiedAt.");
+            return;
+        }
+
+        var value = await lastModifiedAt.LastModifiedAt.GetValueAsync(CancellationToken.None);
+        
+        Assert.IsNotNull(value, "LastModifiedAt should have a value when created with a known timestamp.");
+        
+        var diff = Math.Abs((value.Value.ToUniversalTime() - expectedTimestamp).TotalSeconds);
+        Assert.IsTrue(diff < 2, $"LastModifiedAt should match the requested timestamp. Expected={expectedTimestamp:O}, Actual={value:O}, Diff={diff:F2}s");
     }
 
     [TestMethod]
@@ -66,50 +101,5 @@ public abstract partial class CommonIFolderTests
         using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
 
         Assert.AreSame(prop, watcher.Property);
-    }
-
-    [TestMethod]
-    public async Task LastModifiedAt_UpdateValueAsync_PersistsChange()
-    {
-        var folder = await CreateFolderAsync();
-        if (folder is not ILastModifiedAt { LastModifiedAt: IModifiableStorageProperty<DateTime?> prop })
-            return;
-
-        var newValue = DateTime.Now.AddDays(-1);
-        await prop.UpdateValueAsync(newValue, CancellationToken.None);
-
-        var retrieved = await prop.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(retrieved);
-        Assert.AreEqual(newValue.Year, retrieved.Value.Year);
-        Assert.AreEqual(newValue.Month, retrieved.Value.Month);
-        Assert.AreEqual(newValue.Day, retrieved.Value.Day);
-        Assert.AreEqual(newValue.Hour, retrieved.Value.Hour);
-        Assert.AreEqual(newValue.Minute, retrieved.Value.Minute);
-        Assert.AreEqual(newValue.Second, retrieved.Value.Second);
-    }
-
-    [TestMethod]
-    public async Task LastModifiedAt_UpdateValueAsync_NullThrows()
-    {
-        var folder = await CreateFolderAsync();
-        if (folder is not ILastModifiedAt { LastModifiedAt: IModifiableStorageProperty<DateTime?> prop })
-            return;
-
-        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
-            await prop.UpdateValueAsync(null, CancellationToken.None));
-    }
-
-    [TestMethod]
-    public async Task LastModifiedAt_UpdateValueAsync_ImmediateCancellation()
-    {
-        var folder = await CreateFolderAsync();
-        if (folder is not ILastModifiedAt { LastModifiedAt: IModifiableStorageProperty<DateTime?> prop })
-            return;
-
-        var cts = new CancellationTokenSource();
-        cts.Cancel();
-
-        Assert.ThrowsException<OperationCanceledException>(() =>
-            prop.UpdateValueAsync(DateTime.Now, cts.Token));
     }
 }

--- a/src/CommonIFolderTests.LastModifiedAtOffset.cs
+++ b/src/CommonIFolderTests.LastModifiedAtOffset.cs
@@ -39,8 +39,8 @@ public abstract partial class CommonIFolderTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await lastModifiedAtOffset.LastModifiedAtOffset.GetValueAsync(cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            lastModifiedAtOffset.LastModifiedAtOffset.GetValueAsync(cts.Token));
     }
 
     [TestMethod]
@@ -109,7 +109,7 @@ public abstract partial class CommonIFolderTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
-            await prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
+        Assert.ThrowsException<OperationCanceledException>(() =>
+            prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
     }
 }

--- a/src/CommonIFolderTests.LastModifiedAtOffset.cs
+++ b/src/CommonIFolderTests.LastModifiedAtOffset.cs
@@ -25,8 +25,19 @@ public abstract partial class CommonIFolderTests
             return;
 
         var value = await lastModifiedAtOffset.LastModifiedAtOffset.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(value);
-        Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+
+        switch (LastModifiedAtAvailability)
+        {
+            case PropertyValueAvailability.Always:
+                Assert.IsNotNull(value, "LastModifiedAtOffset should always have a value for this implementation.");
+                Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+                break;
+
+            case PropertyValueAvailability.Maybe:
+                if (value is not null)
+                    Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+                break;
+        }
     }
 
     [TestMethod]
@@ -66,50 +77,5 @@ public abstract partial class CommonIFolderTests
         using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
 
         Assert.AreSame(prop, watcher.Property);
-    }
-
-    [TestMethod]
-    public async Task LastModifiedAtOffset_UpdateValueAsync_PersistsChange()
-    {
-        var folder = await CreateFolderAsync();
-        if (folder is not ILastModifiedAtOffset { LastModifiedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
-            return;
-
-        var newValue = DateTimeOffset.Now.AddDays(-1);
-        await prop.UpdateValueAsync(newValue, CancellationToken.None);
-
-        var retrieved = await prop.GetValueAsync(CancellationToken.None);
-        Assert.IsNotNull(retrieved);
-        Assert.AreEqual(newValue.UtcDateTime.Year, retrieved.Value.UtcDateTime.Year);
-        Assert.AreEqual(newValue.UtcDateTime.Month, retrieved.Value.UtcDateTime.Month);
-        Assert.AreEqual(newValue.UtcDateTime.Day, retrieved.Value.UtcDateTime.Day);
-        Assert.AreEqual(newValue.UtcDateTime.Hour, retrieved.Value.UtcDateTime.Hour);
-        Assert.AreEqual(newValue.UtcDateTime.Minute, retrieved.Value.UtcDateTime.Minute);
-        Assert.AreEqual(newValue.UtcDateTime.Second, retrieved.Value.UtcDateTime.Second);
-    }
-
-    [TestMethod]
-    public async Task LastModifiedAtOffset_UpdateValueAsync_NullThrows()
-    {
-        var folder = await CreateFolderAsync();
-        if (folder is not ILastModifiedAtOffset { LastModifiedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
-            return;
-
-        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
-            await prop.UpdateValueAsync(null, CancellationToken.None));
-    }
-
-    [TestMethod]
-    public async Task LastModifiedAtOffset_UpdateValueAsync_ImmediateCancellation()
-    {
-        var folder = await CreateFolderAsync();
-        if (folder is not ILastModifiedAtOffset { LastModifiedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
-            return;
-
-        var cts = new CancellationTokenSource();
-        cts.Cancel();
-
-        Assert.ThrowsException<OperationCanceledException>(() =>
-            prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
     }
 }

--- a/src/CommonIFolderTests.LastModifiedAtOffset.cs
+++ b/src/CommonIFolderTests.LastModifiedAtOffset.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace OwlCore.Storage.CommonTests;
+
+public abstract partial class CommonIFolderTests
+{
+    [TestMethod]
+    public async Task LastModifiedAtOffset_PropertyName_MatchesInterfaceMember()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastModifiedAtOffset lastModifiedAtOffset)
+            return;
+
+        Assert.AreEqual(nameof(ILastModifiedAtOffset.LastModifiedAtOffset), lastModifiedAtOffset.LastModifiedAtOffset.Name);
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAtOffset_GetValueAsync_ReturnsValue()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastModifiedAtOffset lastModifiedAtOffset)
+            return;
+
+        var value = await lastModifiedAtOffset.LastModifiedAtOffset.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(value);
+        Assert.AreNotEqual(DateTimeOffset.MinValue, value.Value);
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAtOffset_GetValueAsync_ImmediateCancellation()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastModifiedAtOffset lastModifiedAtOffset)
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await lastModifiedAtOffset.LastModifiedAtOffset.GetValueAsync(cts.Token));
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAtOffset_Watcher_ReturnsNewInstanceEachCall()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastModifiedAtOffset { LastModifiedAtOffset: IMutableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        using var watcher1 = await prop.GetWatcherAsync(CancellationToken.None);
+        using var watcher2 = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreNotSame(watcher1, watcher2);
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAtOffset_Watcher_PropertyReferenceIsCorrect()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastModifiedAtOffset { LastModifiedAtOffset: IMutableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        using var watcher = await prop.GetWatcherAsync(CancellationToken.None);
+
+        Assert.AreSame(prop, watcher.Property);
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAtOffset_UpdateValueAsync_PersistsChange()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastModifiedAtOffset { LastModifiedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        var newValue = DateTimeOffset.Now.AddDays(-1);
+        await prop.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await prop.GetValueAsync(CancellationToken.None);
+        Assert.IsNotNull(retrieved);
+        Assert.AreEqual(newValue.UtcDateTime.Year, retrieved.Value.UtcDateTime.Year);
+        Assert.AreEqual(newValue.UtcDateTime.Month, retrieved.Value.UtcDateTime.Month);
+        Assert.AreEqual(newValue.UtcDateTime.Day, retrieved.Value.UtcDateTime.Day);
+        Assert.AreEqual(newValue.UtcDateTime.Hour, retrieved.Value.UtcDateTime.Hour);
+        Assert.AreEqual(newValue.UtcDateTime.Minute, retrieved.Value.UtcDateTime.Minute);
+        Assert.AreEqual(newValue.UtcDateTime.Second, retrieved.Value.UtcDateTime.Second);
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAtOffset_UpdateValueAsync_NullThrows()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastModifiedAtOffset { LastModifiedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            await prop.UpdateValueAsync(null, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task LastModifiedAtOffset_UpdateValueAsync_ImmediateCancellation()
+    {
+        var folder = await CreateFolderAsync();
+        if (folder is not ILastModifiedAtOffset { LastModifiedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop })
+            return;
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await prop.UpdateValueAsync(DateTimeOffset.Now, cts.Token));
+    }
+}

--- a/src/CommonIFolderTests.cs
+++ b/src/CommonIFolderTests.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace OwlCore.Storage.CommonTests;
 
-public abstract class CommonIFolderTests
+public abstract partial class CommonIFolderTests
 {
     /// <summary>
     /// Call the constructor using valid input parameters.

--- a/src/CommonIFolderTests.cs
+++ b/src/CommonIFolderTests.cs
@@ -9,6 +9,45 @@ namespace OwlCore.Storage.CommonTests;
 public abstract partial class CommonIFolderTests
 {
     /// <summary>
+    /// Gets the expected availability of the CreatedAt property value.
+    /// </summary>
+    public virtual PropertyValueAvailability CreatedAtAvailability => PropertyValueAvailability.Always;
+
+    /// <summary>
+    /// Gets the expected availability of the LastModifiedAt property value.
+    /// </summary>
+    public virtual PropertyValueAvailability LastModifiedAtAvailability => PropertyValueAvailability.Always;
+
+    /// <summary>
+    /// Gets the expected availability of the LastAccessedAt property value.
+    /// </summary>
+    public virtual PropertyValueAvailability LastAccessedAtAvailability => PropertyValueAvailability.Always;
+
+    /// <summary>
+    /// Gets the expected update behavior of the LastModifiedAt property.
+    /// </summary>
+    public virtual PropertyUpdateBehavior LastModifiedAtUpdateBehavior => PropertyUpdateBehavior.Immediate;
+
+    /// <summary>
+    /// Gets the expected update behavior of the LastAccessedAt property.
+    /// </summary>
+    public virtual PropertyUpdateBehavior LastAccessedAtUpdateBehavior => PropertyUpdateBehavior.Immediate;
+
+    /// <summary>
+    /// Gets the expected update behavior of the CreatedAt property.
+    /// </summary>
+    public virtual PropertyUpdateBehavior CreatedAtUpdateBehavior => PropertyUpdateBehavior.Immediate;
+
+    /// <summary>
+    /// Gets whether the implementation allows <see cref="IStorable.Id"/> to equal <see cref="IStorable.Name"/>.
+    /// </summary>
+    /// <remarks>
+    /// Most implementations should keep this <c>false</c> to ensure IDs are unique and not derived from names.
+    /// Content-addressed storage (e.g., IPFS) may set this to <c>true</c> since the CID serves as both a unique identifier and a valid name.
+    /// </remarks>
+    public virtual bool AllowsIdEqualToName => false;
+
+    /// <summary>
     /// Call the constructor using valid input parameters.
     /// </summary>
     public abstract Task<IFolder> CreateFolderAsync();
@@ -17,6 +56,39 @@ public abstract partial class CommonIFolderTests
     /// Creates a folder with items in it.
     /// </summary>
     public abstract Task<IFolder> CreateFolderWithItems(int fileCount, int folderCount);
+
+    /// <summary>
+    /// Creates a folder with a specific CreatedAt timestamp.
+    /// </summary>
+    /// <param name="createdAt">The creation timestamp to apply.</param>
+    /// <returns>The created folder, or null if the implementation doesn't support setting CreatedAt.</returns>
+    /// <remarks>
+    /// Implementations must explicitly return null if they don't support setting CreatedAt,
+    /// which signals the test should be skipped. This ensures gaps are surfaced rather than silently ignored.
+    /// </remarks>
+    public abstract Task<IFolder?> CreateFolderWithCreatedAtAsync(DateTime createdAt);
+
+    /// <summary>
+    /// Creates a folder with a specific LastModifiedAt timestamp.
+    /// </summary>
+    /// <param name="lastModifiedAt">The last modified timestamp to apply.</param>
+    /// <returns>The created folder, or null if the implementation doesn't support setting LastModifiedAt.</returns>
+    /// <remarks>
+    /// Implementations must explicitly return null if they don't support setting LastModifiedAt,
+    /// which signals the test should be skipped. This ensures gaps are surfaced rather than silently ignored.
+    /// </remarks>
+    public abstract Task<IFolder?> CreateFolderWithLastModifiedAtAsync(DateTime lastModifiedAt);
+
+    /// <summary>
+    /// Creates a folder with a specific LastAccessedAt timestamp.
+    /// </summary>
+    /// <param name="lastAccessedAt">The last accessed timestamp to apply.</param>
+    /// <returns>The created folder, or null if the implementation doesn't support setting LastAccessedAt.</returns>
+    /// <remarks>
+    /// Implementations must explicitly return null if they don't support setting LastAccessedAt,
+    /// which signals the test should be skipped. This ensures gaps are surfaced rather than silently ignored.
+    /// </remarks>
+    public abstract Task<IFolder?> CreateFolderWithLastAccessedAtAsync(DateTime lastAccessedAt);
 
     [TestMethod]
     public Task ConstructorCall_ValidParameters()
@@ -39,7 +111,9 @@ public abstract partial class CommonIFolderTests
         var folder = await CreateFolderAsync();
 
         Assert.IsFalse(string.IsNullOrWhiteSpace(folder.Id));
-        Assert.AreNotEqual(folder.Name, folder.Id, "Names should not be used as an unique identifier. Use something more specific.");
+
+        if (!AllowsIdEqualToName)
+            Assert.AreNotEqual(folder.Name, folder.Id, "Names should not be used as a unique identifier. Use something more specific.");
     }
 
     [TestMethod]
@@ -106,7 +180,7 @@ public abstract partial class CommonIFolderTests
 
         var folder = await CreateFolderAsync();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () => await folder.GetItemsAsync(type, cancellationTokenSource.Token).ToListAsync(cancellationToken: cancellationTokenSource.Token), "Does not cancel immediately if a canceled token is passed.");
+        await AssertEx.ThrowsExceptionAsync<OperationCanceledException>(async () => await folder.GetItemsAsync(type, cancellationTokenSource.Token).ToListAsync(cancellationToken: cancellationTokenSource.Token), "Does not cancel immediately if a canceled token is passed.");
     }
 
     [TestMethod]
@@ -131,7 +205,7 @@ public abstract partial class CommonIFolderTests
         var cancellationTokenSource = new CancellationTokenSource();
         var folder = await CreateFolderWithItems(fileCount, folderCount);
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+        await AssertEx.ThrowsExceptionAsync<OperationCanceledException>(async () =>
         {
             var index = 0;
             await foreach (var item in folder.GetItemsAsync(type, cancellationTokenSource.Token))

--- a/src/CommonIModifiableFolderTests.CopyMovePropertyPreservation.cs
+++ b/src/CommonIModifiableFolderTests.CopyMovePropertyPreservation.cs
@@ -1,0 +1,160 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OwlCore.Storage.CommonTests;
+
+/// <summary>
+/// Tests for timestamp preservation during copy and move operations.
+/// </summary>
+public abstract partial class CommonIModifiableFolderTests
+{
+    /// <summary>
+    /// Tests that CreateCopyOfAsync preserves only LastModifiedAt (not CreatedAt or LastAccessedAt).
+    /// This matches native System.IO and Windows.Storage copy behavior.
+    /// </summary>
+    [TestMethod]
+    public async Task CreateCopyOfAsync_PropertyPreservation()
+    {
+        var sourceFolder = await CreateModifiableFolderAsync();
+        var destinationFolder = await CreateModifiableFolderAsync();
+
+        // Create a file with known timestamps
+        var oldCreatedAt = DateTime.UtcNow.AddDays(-30);
+        var oldLastModifiedAt = DateTime.UtcNow.AddDays(-15);
+        var oldLastAccessedAt = DateTime.UtcNow.AddDays(-7);
+
+        var originalFile = await CreateFileInFolderWithTimestampsAsync(sourceFolder, oldCreatedAt, oldLastModifiedAt, oldLastAccessedAt);
+
+        // If implementation can't create files with timestamps, nothing to test
+        if (originalFile is null)
+            return;
+
+        // Capture source properties
+        DateTime? sourceCreatedAt = null;
+        DateTime? sourceLastModifiedAt = null;
+        DateTime? sourceLastAccessedAt = null;
+
+        if (originalFile is ICreatedAt createdAt)
+            sourceCreatedAt = await createdAt.CreatedAt.GetValueAsync(CancellationToken.None);
+        
+        if (originalFile is ILastModifiedAt lastModifiedAt)
+            sourceLastModifiedAt = await lastModifiedAt.LastModifiedAt.GetValueAsync(CancellationToken.None);
+        
+        if (originalFile is ILastAccessedAt lastAccessedAt)
+            sourceLastAccessedAt = await lastAccessedAt.LastAccessedAt.GetValueAsync(CancellationToken.None);
+
+        // If no properties are implemented, nothing to test
+        if (sourceCreatedAt is null && sourceLastModifiedAt is null && sourceLastAccessedAt is null)
+            return;
+
+        // Perform copy
+        var copy = await destinationFolder.CreateCopyOfAsync(originalFile, overwrite: true);
+
+        // Assert copy semantics:
+        // - CreatedAt: NOT preserved (new file gets current time)
+        // - LastModifiedAt: PRESERVED (content age)
+        // - LastAccessedAt: NOT preserved (new file gets current time)
+
+        if (sourceCreatedAt is not null && copy is ICreatedAt copyCreatedAt)
+        {
+            var destValue = await copyCreatedAt.CreatedAt.GetValueAsync(CancellationToken.None);
+            var preserved = AreTimestampsEqualForPreservation(sourceCreatedAt.Value, destValue);
+            Assert.IsFalse(preserved, $"Copy should NOT preserve CreatedAt. Source={sourceCreatedAt:O}, Dest={destValue:O}");
+        }
+
+        if (sourceLastModifiedAt is not null && copy is ILastModifiedAt copyLastModifiedAt)
+        {
+            var destValue = await copyLastModifiedAt.LastModifiedAt.GetValueAsync(CancellationToken.None);
+            var preserved = AreTimestampsEqualForPreservation(sourceLastModifiedAt.Value, destValue);
+            Assert.IsTrue(preserved, $"Copy SHOULD preserve LastModifiedAt. Source={sourceLastModifiedAt:O}, Dest={destValue:O}");
+        }
+
+        if (sourceLastAccessedAt is not null && copy is ILastAccessedAt copyLastAccessedAt)
+        {
+            var destValue = await copyLastAccessedAt.LastAccessedAt.GetValueAsync(CancellationToken.None);
+            var preserved = AreTimestampsEqualForPreservation(sourceLastAccessedAt.Value, destValue);
+            Assert.IsFalse(preserved, $"Copy should NOT preserve LastAccessedAt. Source={sourceLastAccessedAt:O}, Dest={destValue:O}");
+        }
+    }
+
+    /// <summary>
+    /// Tests that MoveFromAsync preserves all timestamps (CreatedAt, LastModifiedAt, LastAccessedAt).
+    /// This matches native System.IO and Windows.Storage move behavior.
+    /// </summary>
+    [TestMethod]
+    public async Task MoveFromAsync_PropertyPreservation()
+    {
+        var sourceFolder = await CreateModifiableFolderAsync();
+        var destinationFolder = await CreateModifiableFolderAsync();
+
+        // Create a file with known timestamps
+        var oldCreatedAt = DateTime.UtcNow.AddDays(-30);
+        var oldLastModifiedAt = DateTime.UtcNow.AddDays(-15);
+        var oldLastAccessedAt = DateTime.UtcNow.AddDays(-7);
+
+        var originalFile = await CreateFileInFolderWithTimestampsAsync(sourceFolder, oldCreatedAt, oldLastModifiedAt, oldLastAccessedAt) as IChildFile;
+
+        // If implementation can't create files with timestamps, nothing to test
+        if (originalFile is null)
+            return;
+
+        // Capture source properties
+        DateTime? sourceCreatedAt = null;
+        DateTime? sourceLastModifiedAt = null;
+        DateTime? sourceLastAccessedAt = null;
+
+        if (originalFile is ICreatedAt createdAt)
+            sourceCreatedAt = await createdAt.CreatedAt.GetValueAsync(CancellationToken.None);
+        
+        if (originalFile is ILastModifiedAt lastModifiedAt)
+            sourceLastModifiedAt = await lastModifiedAt.LastModifiedAt.GetValueAsync(CancellationToken.None);
+        
+        if (originalFile is ILastAccessedAt lastAccessedAt)
+            sourceLastAccessedAt = await lastAccessedAt.LastAccessedAt.GetValueAsync(CancellationToken.None);
+
+        // If no properties are implemented, nothing to test
+        if (sourceCreatedAt is null && sourceLastModifiedAt is null && sourceLastAccessedAt is null)
+            return;
+
+        // Perform move
+        var moved = await destinationFolder.MoveFromAsync(originalFile, sourceFolder, overwrite: true);
+
+        // Assert move semantics: ALL timestamps should be preserved
+
+        if (sourceCreatedAt is not null && moved is ICreatedAt movedCreatedAt)
+        {
+            var destValue = await movedCreatedAt.CreatedAt.GetValueAsync(CancellationToken.None);
+            var preserved = AreTimestampsEqualForPreservation(sourceCreatedAt.Value, destValue);
+            Assert.IsTrue(preserved, $"Move SHOULD preserve CreatedAt. Source={sourceCreatedAt:O}, Dest={destValue:O}");
+        }
+
+        if (sourceLastModifiedAt is not null && moved is ILastModifiedAt movedLastModifiedAt)
+        {
+            var destValue = await movedLastModifiedAt.LastModifiedAt.GetValueAsync(CancellationToken.None);
+            var preserved = AreTimestampsEqualForPreservation(sourceLastModifiedAt.Value, destValue);
+            Assert.IsTrue(preserved, $"Move SHOULD preserve LastModifiedAt. Source={sourceLastModifiedAt:O}, Dest={destValue:O}");
+        }
+
+        if (sourceLastAccessedAt is not null && moved is ILastAccessedAt movedLastAccessedAt)
+        {
+            var destValue = await movedLastAccessedAt.LastAccessedAt.GetValueAsync(CancellationToken.None);
+            var preserved = AreTimestampsEqualForPreservation(sourceLastAccessedAt.Value, destValue);
+            Assert.IsTrue(preserved, $"Move SHOULD preserve LastAccessedAt. Source={sourceLastAccessedAt:O}, Dest={destValue:O}");
+        }
+    }
+
+    /// <summary>
+    /// Compares two DateTime values with tolerance for filesystem precision differences.
+    /// </summary>
+    private static bool AreTimestampsEqualForPreservation(DateTime? source, DateTime? dest)
+    {
+        if (source is null || dest is null)
+            return false;
+        
+        // Allow 2 second tolerance for filesystem precision differences
+        return Math.Abs((source.Value - dest.Value).TotalSeconds) < 2;
+    }
+}

--- a/src/CommonIModifiableFolderTests.CrossImplementationCopyMove.cs
+++ b/src/CommonIModifiableFolderTests.CrossImplementationCopyMove.cs
@@ -1,0 +1,250 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OwlCore.Storage.CommonTests;
+
+/// <summary>
+/// Tests for cross-implementation copy and move operations.
+/// Tests fallback paths that copy timestamps when bridging different storage implementations.
+/// </summary>
+public abstract partial class CommonIModifiableFolderTests
+{
+    /// <summary>
+    /// Tests copying FROM the real implementation (with known timestamp) TO a mock with timestamp support.
+    /// Verifies fallback path preserves only LastModifiedAt (copy semantics).
+    /// </summary>
+    [TestMethod]
+    public async Task CreateCopyOfAsync_ToMockWithTimestamps_PreservesLastModifiedAt()
+    {
+        var sourceFolder = await CreateModifiableFolderWithItems(0, 0);
+        var expectedTimestamp = DateTime.UtcNow.AddDays(-15);
+        
+        // Create source file with known timestamp
+        var sourceFile = await CreateFileInFolderWithLastModifiedAtAsync(sourceFolder, expectedTimestamp);
+        
+        // Skip if implementation doesn't support creating files with known timestamps
+        if (sourceFile is null)
+            return;
+
+        // Dest: mock that forces fallback path (no ICreateCopyOf)
+        var destFolder = new MockStorageFolder("mock_dest", null, createFilesWithTimestamps: true);
+
+        // Act - uses fallback path
+        var copy = await destFolder.CreateCopyOfAsync(sourceFile, overwrite: true);
+
+        // Assert - only LastModifiedAt should be preserved (copy semantics)
+        Assert.IsInstanceOfType(copy, typeof(MockStorageFile));
+        var mockCopy = (MockStorageFile)copy;
+
+        AssertTimestampPreservedUtc(expectedTimestamp, mockCopy.LastModifiedAtValue?.UtcDateTime, "LastModifiedAt");
+    }
+
+    /// <summary>
+    /// Tests copying FROM a mock with timestamps TO the real implementation.
+    /// Verifies fallback path preserves only LastModifiedAt (copy semantics) when destination supports it.
+    /// </summary>
+    /// <remarks>
+    /// Copy semantics: The copy extension reads timestamps from source and attempts to write them to destination.
+    /// If the destination property is read-only (not IModifiableStorageProperty), the extension cannot set the value,
+    /// so we only assert preservation when the destination explicitly supports modifiable timestamps.
+    /// This accommodates implementations like archives where entry timestamps are determined at creation time
+    /// and cannot be modified after the fact.
+    /// </remarks>
+    [TestMethod]
+    public async Task CreateCopyOfAsync_FromMockWithTimestamps_PreservesLastModifiedAt()
+    {
+        // Source: mock with timestamps
+        var sourceFolder = MockStorageFolder.CreateWithItems("mock_source", 1, 0, filesWithTimestamps: true);
+        var sourceFile = (MockStorageFile)await sourceFolder.GetFilesAsync().FirstAsync();
+
+        // Set backdated timestamps
+        var oldLastModifiedAt = DateTimeOffset.UtcNow.AddDays(-15);
+        sourceFile.LastModifiedAtValue = oldLastModifiedAt;
+
+        // Dest: real implementation
+        var destFolder = await CreateModifiableFolderWithItems(0, 0);
+
+        // Act - uses fallback path
+        var copy = await destFolder.CreateCopyOfAsync(sourceFile, overwrite: true);
+
+        // Assert - only LastModifiedAt should be preserved (copy semantics).
+        // We can only assert preservation if the destination property is modifiable,
+        // because otherwise the copy extension had no way to set the timestamp.
+        // Read-only timestamp implementations (e.g., archives) will skip this assertion
+        // but the copy operation itself still succeeds.
+        if (copy is ILastModifiedAt { LastModifiedAt: IModifiableStorageProperty<DateTime?> })
+        {
+            var destLastModifiedAt = await ((ILastModifiedAt)copy).LastModifiedAt.GetValueAsync(CancellationToken.None);
+            AssertTimestampPreservedUtc(oldLastModifiedAt.UtcDateTime, destLastModifiedAt?.ToUniversalTime(), "LastModifiedAt");
+        }
+    }
+
+    /// <summary>
+    /// Tests copying FROM a mock without timestamps TO the real implementation.
+    /// Verifies copy succeeds even when source has no timestamp properties.
+    /// </summary>
+    [TestMethod]
+    public async Task CreateCopyOfAsync_FromMockWithoutTimestamps_Succeeds()
+    {
+        // Source: mock WITHOUT timestamps
+        var sourceFolder = MockStorageFolder.CreateWithItems("mock_source", 1, 0, filesWithTimestamps: false);
+        var sourceFile = await sourceFolder.GetFilesAsync().FirstAsync();
+        Assert.IsInstanceOfType(sourceFile, typeof(MockStorageFileNoTimestamps));
+
+        // Dest: real implementation
+        var destFolder = await CreateModifiableFolderWithItems(0, 0);
+
+        // Act - should succeed without throwing
+        var copy = await destFolder.CreateCopyOfAsync(sourceFile, overwrite: true);
+
+        // Assert - copy succeeded
+        Assert.IsNotNull(copy);
+        Assert.AreEqual(sourceFile.Name, copy.Name);
+    }
+
+    /// <summary>
+    /// Tests moving FROM the real implementation (with known timestamps) TO a mock with timestamp support.
+    /// Verifies fallback move (copy + delete) preserves ALL timestamps (move semantics).
+    /// </summary>
+    [TestMethod]
+    public async Task MoveFromAsync_ToMockWithTimestamps_PreservesAllTimestamps()
+    {
+        var sourceFolder = await CreateModifiableFolderWithItems(0, 0);
+        
+        var expectedCreatedAt = DateTime.UtcNow.AddDays(-30);
+        var expectedLastModifiedAt = DateTime.UtcNow.AddDays(-15);
+        var expectedLastAccessedAt = DateTime.UtcNow.AddDays(-7);
+        
+        // Create source file with known timestamps
+        var sourceFile = await CreateFileInFolderWithTimestampsAsync(sourceFolder, expectedCreatedAt, expectedLastModifiedAt, expectedLastAccessedAt);
+        
+        // Skip if implementation doesn't support creating files with known timestamps
+        if (sourceFile is null)
+            return;
+
+        if (sourceFile is not IChildFile childFile)
+            return;
+
+        // Dest: mock that forces fallback path
+        var destFolder = new MockStorageFolder("mock_dest", null, createFilesWithTimestamps: true);
+
+        // Act - uses fallback path (copy + delete)
+        var moved = await destFolder.MoveFromAsync(childFile, sourceFolder, overwrite: true);
+
+        // Assert - ALL timestamps should be preserved (move semantics)
+        Assert.IsInstanceOfType(moved, typeof(MockStorageFile));
+        var mockMoved = (MockStorageFile)moved;
+
+        // Check each timestamp - only assert if source had it
+        if (sourceFile is ICreatedAt)
+            AssertTimestampPreservedUtc(expectedCreatedAt, mockMoved.CreatedAtValue?.UtcDateTime, "CreatedAt");
+        if (sourceFile is ILastModifiedAt)
+            AssertTimestampPreservedUtc(expectedLastModifiedAt, mockMoved.LastModifiedAtValue?.UtcDateTime, "LastModifiedAt");
+        if (sourceFile is ILastAccessedAt)
+            AssertTimestampPreservedUtc(expectedLastAccessedAt, mockMoved.LastAccessedAtValue?.UtcDateTime, "LastAccessedAt");
+
+        // Source should be deleted
+        var remaining = await sourceFolder.GetFilesAsync().ToListAsync();
+        Assert.AreEqual(0, remaining.Count, "Source file should be deleted after move");
+    }
+
+    /// <summary>
+    /// Tests moving FROM a mock with timestamps TO the real implementation.
+    /// Verifies fallback move preserves ALL timestamps (move semantics) when destination supports it.
+    /// </summary>
+    /// <remarks>
+    /// Move semantics: The move extension reads all timestamps from source and attempts to write them to destination.
+    /// If the destination properties are read-only (not IModifiableStorageProperty), the extension cannot set the values,
+    /// so we only assert preservation when the destination explicitly supports modifiable timestamps.
+    /// This accommodates implementations like archives where entry timestamps are determined at creation time
+    /// and cannot be modified after the fact.
+    /// </remarks>
+    [TestMethod]
+    public async Task MoveFromAsync_FromMockWithTimestamps_PreservesAllTimestamps()
+    {
+        // Source: mock with timestamps
+        var sourceFolder = MockStorageFolder.CreateWithItems("mock_source", 1, 0, filesWithTimestamps: true);
+        var sourceFile = (MockStorageFile)await sourceFolder.GetFilesAsync().FirstAsync();
+
+        var oldCreatedAt = DateTimeOffset.UtcNow.AddDays(-30);
+        var oldLastModifiedAt = DateTimeOffset.UtcNow.AddDays(-15);
+        var oldLastAccessedAt = DateTimeOffset.UtcNow.AddDays(-7);
+        sourceFile.CreatedAtValue = oldCreatedAt;
+        sourceFile.LastModifiedAtValue = oldLastModifiedAt;
+        sourceFile.LastAccessedAtValue = oldLastAccessedAt;
+
+        // Dest: real implementation
+        var destFolder = await CreateModifiableFolderWithItems(0, 0);
+
+        // Act - uses fallback path
+        var moved = await destFolder.MoveFromAsync(sourceFile, sourceFolder, overwrite: true);
+
+        // Assert - timestamps should be preserved only if destination supports modifiable properties.
+        // We can only assert preservation if the destination property is modifiable,
+        // because otherwise the move extension had no way to set the timestamp.
+        // Read-only timestamp implementations (e.g., archives) will skip these assertions
+        // but the move operation itself still succeeds.
+        
+        if (moved is ICreatedAt { CreatedAt: IModifiableStorageProperty<DateTime?> })
+        {
+            var destCreatedAt = await ((ICreatedAt)moved).CreatedAt.GetValueAsync(CancellationToken.None);
+            AssertTimestampPreservedUtc(oldCreatedAt.UtcDateTime, destCreatedAt?.ToUniversalTime(), "CreatedAt");
+        }
+
+        if (moved is ILastModifiedAt { LastModifiedAt: IModifiableStorageProperty<DateTime?> })
+        {
+            var destLastModifiedAt = await ((ILastModifiedAt)moved).LastModifiedAt.GetValueAsync(CancellationToken.None);
+            AssertTimestampPreservedUtc(oldLastModifiedAt.UtcDateTime, destLastModifiedAt?.ToUniversalTime(), "LastModifiedAt");
+        }
+
+        if (moved is ILastAccessedAt { LastAccessedAt: IModifiableStorageProperty<DateTime?> })
+        {
+            var destLastAccessedAt = await ((ILastAccessedAt)moved).LastAccessedAt.GetValueAsync(CancellationToken.None);
+            AssertTimestampPreservedUtc(oldLastAccessedAt.UtcDateTime, destLastAccessedAt?.ToUniversalTime(), "LastAccessedAt");
+        }
+
+        // Source should be deleted
+        var remaining = await sourceFolder.GetFilesAsync().ToListAsync();
+        Assert.AreEqual(0, remaining.Count, "Source file should be deleted after move");
+    }
+
+    /// <summary>
+    /// Tests that file content is preserved during cross-implementation copy.
+    /// </summary>
+    [TestMethod]
+    public async Task CreateCopyOfAsync_CrossImplementation_PreservesContent()
+    {
+        // Source: mock with known content
+        var sourceFolder = new MockStorageFolder("mock_source");
+        var expectedContent = global::System.Text.Encoding.UTF8.GetBytes("Cross-implementation content test!");
+        var sourceFile = new MockStorageFile("content_test.txt", sourceFolder, expectedContent);
+        sourceFolder.AddChild(sourceFile);
+
+        // Dest: real implementation
+        var destFolder = await CreateModifiableFolderWithItems(0, 0);
+
+        // Act
+        var copy = await destFolder.CreateCopyOfAsync(sourceFile, overwrite: true);
+
+        // Assert
+        using var stream = await copy.OpenStreamAsync(FileAccess.Read);
+        var actualContent = new byte[stream.Length];
+        await stream.ReadAsync(actualContent, 0, actualContent.Length);
+
+        CollectionAssert.AreEqual(expectedContent, actualContent, "File content should be preserved during cross-implementation copy");
+    }
+
+    private static void AssertTimestampPreservedUtc(DateTime? expected, DateTime? actual, string propertyName)
+    {
+        Assert.IsNotNull(actual, $"{propertyName} should not be null on destination");
+        Assert.IsNotNull(expected, $"Expected {propertyName} should not be null");
+
+        var diff = Math.Abs((actual.Value - expected.Value).TotalSeconds);
+        Assert.IsTrue(diff < 2,
+            $"{propertyName} should be preserved. Expected={expected:O}, Actual={actual:O}, Diff={diff:F2}s");
+    }
+}

--- a/src/CommonIModifiableFolderTests.FilePropertyPersistence.cs
+++ b/src/CommonIModifiableFolderTests.FilePropertyPersistence.cs
@@ -1,0 +1,190 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OwlCore.Storage.CommonTests;
+
+public abstract partial class CommonIModifiableFolderTests
+{
+    [TestMethod]
+    public async Task File_CreatedAt_UpdateValueAsync_PersistsChange()
+    {
+        var parent = await CreateModifiableFolderWithItems(1, 0);
+        var instance1 = await parent.GetFilesAsync().FirstOrDefaultAsync();
+        var instance2 = await parent.GetFilesAsync().FirstOrDefaultAsync();
+        
+        if (instance1 is null || instance2 is null)
+            return;
+
+        if (instance1 is not ICreatedAt { CreatedAt: IModifiableStorageProperty<DateTime?> prop1 })
+            return;
+        
+        if (instance2 is not ICreatedAt instance2Prop)
+            return;
+
+        var initialValue = await instance2Prop.CreatedAt.GetValueAsync(CancellationToken.None);
+        var newValue = DateTime.Now.AddDays(-7);
+        
+        await prop1.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await instance2Prop.CreatedAt.GetValueAsync(CancellationToken.None);
+        
+        Assert.IsNotNull(retrieved);
+        Assert.AreNotEqual(initialValue, retrieved, $"instance2 should see updated value. Initial={initialValue:O}, Retrieved={retrieved:O}, Expected={newValue:O}");
+        Assert.AreEqual(newValue.Year, retrieved.Value.Year);
+        Assert.AreEqual(newValue.Month, retrieved.Value.Month);
+        Assert.AreEqual(newValue.Day, retrieved.Value.Day);
+    }
+
+    [TestMethod]
+    public async Task File_CreatedAtOffset_UpdateValueAsync_PersistsChange()
+    {
+        var parent = await CreateModifiableFolderWithItems(1, 0);
+        var instance1 = await parent.GetFilesAsync().FirstOrDefaultAsync();
+        var instance2 = await parent.GetFilesAsync().FirstOrDefaultAsync();
+        
+        if (instance1 is null || instance2 is null)
+            return;
+
+        if (instance1 is not ICreatedAtOffset { CreatedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop1 })
+            return;
+        
+        if (instance2 is not ICreatedAtOffset instance2Prop)
+            return;
+
+        var initialValue = await instance2Prop.CreatedAtOffset.GetValueAsync(CancellationToken.None);
+        var newValue = DateTimeOffset.Now.AddDays(-7);
+        
+        await prop1.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await instance2Prop.CreatedAtOffset.GetValueAsync(CancellationToken.None);
+        
+        Assert.IsNotNull(retrieved);
+        Assert.AreNotEqual(initialValue, retrieved, $"instance2 should see updated value. Initial={initialValue:O}, Retrieved={retrieved:O}, Expected={newValue:O}");
+        Assert.AreEqual(newValue.UtcDateTime.Year, retrieved.Value.UtcDateTime.Year);
+        Assert.AreEqual(newValue.UtcDateTime.Month, retrieved.Value.UtcDateTime.Month);
+        Assert.AreEqual(newValue.UtcDateTime.Day, retrieved.Value.UtcDateTime.Day);
+    }
+
+    [TestMethod]
+    public async Task File_LastAccessedAt_UpdateValueAsync_PersistsChange()
+    {
+        var parent = await CreateModifiableFolderWithItems(1, 0);
+        var instance1 = await parent.GetFilesAsync().FirstOrDefaultAsync();
+        var instance2 = await parent.GetFilesAsync().FirstOrDefaultAsync();
+        
+        if (instance1 is null || instance2 is null)
+            return;
+
+        if (instance1 is not ILastAccessedAt { LastAccessedAt: IModifiableStorageProperty<DateTime?> prop1 })
+            return;
+        
+        if (instance2 is not ILastAccessedAt instance2Prop)
+            return;
+
+        var initialValue = await instance2Prop.LastAccessedAt.GetValueAsync(CancellationToken.None);
+        var newValue = DateTime.Now.AddDays(-7);
+        
+        await prop1.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await instance2Prop.LastAccessedAt.GetValueAsync(CancellationToken.None);
+        
+        Assert.IsNotNull(retrieved);
+        Assert.AreNotEqual(initialValue, retrieved, $"instance2 should see updated value. Initial={initialValue:O}, Retrieved={retrieved:O}, Expected={newValue:O}");
+        Assert.AreEqual(newValue.Year, retrieved.Value.Year);
+        Assert.AreEqual(newValue.Month, retrieved.Value.Month);
+        Assert.AreEqual(newValue.Day, retrieved.Value.Day);
+    }
+
+    [TestMethod]
+    public async Task File_LastAccessedAtOffset_UpdateValueAsync_PersistsChange()
+    {
+        var parent = await CreateModifiableFolderWithItems(1, 0);
+        var instance1 = await parent.GetFilesAsync().FirstOrDefaultAsync();
+        var instance2 = await parent.GetFilesAsync().FirstOrDefaultAsync();
+        
+        if (instance1 is null || instance2 is null)
+            return;
+
+        if (instance1 is not ILastAccessedAtOffset { LastAccessedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop1 })
+            return;
+        
+        if (instance2 is not ILastAccessedAtOffset instance2Prop)
+            return;
+
+        var initialValue = await instance2Prop.LastAccessedAtOffset.GetValueAsync(CancellationToken.None);
+        var newValue = DateTimeOffset.Now.AddDays(-7);
+        
+        await prop1.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await instance2Prop.LastAccessedAtOffset.GetValueAsync(CancellationToken.None);
+        
+        Assert.IsNotNull(retrieved);
+        Assert.AreNotEqual(initialValue, retrieved, $"instance2 should see updated value. Initial={initialValue:O}, Retrieved={retrieved:O}, Expected={newValue:O}");
+        Assert.AreEqual(newValue.UtcDateTime.Year, retrieved.Value.UtcDateTime.Year);
+        Assert.AreEqual(newValue.UtcDateTime.Month, retrieved.Value.UtcDateTime.Month);
+        Assert.AreEqual(newValue.UtcDateTime.Day, retrieved.Value.UtcDateTime.Day);
+    }
+
+    [TestMethod]
+    public async Task File_LastModifiedAt_UpdateValueAsync_PersistsChange()
+    {
+        var parent = await CreateModifiableFolderWithItems(1, 0);
+        var instance1 = await parent.GetFilesAsync().FirstOrDefaultAsync();
+        var instance2 = await parent.GetFilesAsync().FirstOrDefaultAsync();
+        
+        if (instance1 is null || instance2 is null)
+            return;
+
+        if (instance1 is not ILastModifiedAt { LastModifiedAt: IModifiableStorageProperty<DateTime?> prop1 })
+            return;
+        
+        if (instance2 is not ILastModifiedAt instance2Prop)
+            return;
+
+        var initialValue = await instance2Prop.LastModifiedAt.GetValueAsync(CancellationToken.None);
+        var newValue = DateTime.Now.AddDays(-7);
+        
+        await prop1.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await instance2Prop.LastModifiedAt.GetValueAsync(CancellationToken.None);
+        
+        Assert.IsNotNull(retrieved);
+        Assert.AreNotEqual(initialValue, retrieved, $"instance2 should see updated value. Initial={initialValue:O}, Retrieved={retrieved:O}, Expected={newValue:O}");
+        Assert.AreEqual(newValue.Year, retrieved.Value.Year);
+        Assert.AreEqual(newValue.Month, retrieved.Value.Month);
+        Assert.AreEqual(newValue.Day, retrieved.Value.Day);
+    }
+
+    [TestMethod]
+    public async Task File_LastModifiedAtOffset_UpdateValueAsync_PersistsChange()
+    {
+        var parent = await CreateModifiableFolderWithItems(1, 0);
+        var instance1 = await parent.GetFilesAsync().FirstOrDefaultAsync();
+        var instance2 = await parent.GetFilesAsync().FirstOrDefaultAsync();
+        
+        if (instance1 is null || instance2 is null)
+            return;
+
+        if (instance1 is not ILastModifiedAtOffset { LastModifiedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop1 })
+            return;
+        
+        if (instance2 is not ILastModifiedAtOffset instance2Prop)
+            return;
+
+        var initialValue = await instance2Prop.LastModifiedAtOffset.GetValueAsync(CancellationToken.None);
+        var newValue = DateTimeOffset.Now.AddDays(-7);
+        
+        await prop1.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await instance2Prop.LastModifiedAtOffset.GetValueAsync(CancellationToken.None);
+        
+        Assert.IsNotNull(retrieved);
+        Assert.AreNotEqual(initialValue, retrieved, $"instance2 should see updated value. Initial={initialValue:O}, Retrieved={retrieved:O}, Expected={newValue:O}");
+        Assert.AreEqual(newValue.UtcDateTime.Year, retrieved.Value.UtcDateTime.Year);
+        Assert.AreEqual(newValue.UtcDateTime.Month, retrieved.Value.UtcDateTime.Month);
+        Assert.AreEqual(newValue.UtcDateTime.Day, retrieved.Value.UtcDateTime.Day);
+    }
+}

--- a/src/CommonIModifiableFolderTests.FolderPropertyPersistence.cs
+++ b/src/CommonIModifiableFolderTests.FolderPropertyPersistence.cs
@@ -1,0 +1,190 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OwlCore.Storage.CommonTests;
+
+public abstract partial class CommonIModifiableFolderTests
+{
+    [TestMethod]
+    public async Task Folder_CreatedAt_UpdateValueAsync_PersistsChange()
+    {
+        var parent = await CreateModifiableFolderWithItems(0, 1);
+        var instance1 = await parent.GetFoldersAsync().FirstOrDefaultAsync();
+        var instance2 = await parent.GetFoldersAsync().FirstOrDefaultAsync();
+        
+        if (instance1 is null || instance2 is null)
+            return;
+
+        if (instance1 is not ICreatedAt { CreatedAt: IModifiableStorageProperty<DateTime?> prop1 })
+            return;
+        
+        if (instance2 is not ICreatedAt instance2Prop)
+            return;
+
+        var initialValue = await instance2Prop.CreatedAt.GetValueAsync(CancellationToken.None);
+        var newValue = DateTime.Now.AddDays(-7);
+        
+        await prop1.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await instance2Prop.CreatedAt.GetValueAsync(CancellationToken.None);
+        
+        Assert.IsNotNull(retrieved);
+        Assert.AreNotEqual(initialValue, retrieved, $"instance2 should see updated value. Initial={initialValue:O}, Retrieved={retrieved:O}, Expected={newValue:O}");
+        Assert.AreEqual(newValue.Year, retrieved.Value.Year);
+        Assert.AreEqual(newValue.Month, retrieved.Value.Month);
+        Assert.AreEqual(newValue.Day, retrieved.Value.Day);
+    }
+
+    [TestMethod]
+    public async Task Folder_CreatedAtOffset_UpdateValueAsync_PersistsChange()
+    {
+        var parent = await CreateModifiableFolderWithItems(0, 1);
+        var instance1 = await parent.GetFoldersAsync().FirstOrDefaultAsync();
+        var instance2 = await parent.GetFoldersAsync().FirstOrDefaultAsync();
+        
+        if (instance1 is null || instance2 is null)
+            return;
+
+        if (instance1 is not ICreatedAtOffset { CreatedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop1 })
+            return;
+        
+        if (instance2 is not ICreatedAtOffset instance2Prop)
+            return;
+
+        var initialValue = await instance2Prop.CreatedAtOffset.GetValueAsync(CancellationToken.None);
+        var newValue = DateTimeOffset.Now.AddDays(-7);
+        
+        await prop1.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await instance2Prop.CreatedAtOffset.GetValueAsync(CancellationToken.None);
+        
+        Assert.IsNotNull(retrieved);
+        Assert.AreNotEqual(initialValue, retrieved, $"instance2 should see updated value. Initial={initialValue:O}, Retrieved={retrieved:O}, Expected={newValue:O}");
+        Assert.AreEqual(newValue.UtcDateTime.Year, retrieved.Value.UtcDateTime.Year);
+        Assert.AreEqual(newValue.UtcDateTime.Month, retrieved.Value.UtcDateTime.Month);
+        Assert.AreEqual(newValue.UtcDateTime.Day, retrieved.Value.UtcDateTime.Day);
+    }
+
+    [TestMethod]
+    public async Task Folder_LastAccessedAt_UpdateValueAsync_PersistsChange()
+    {
+        var parent = await CreateModifiableFolderWithItems(0, 1);
+        var instance1 = await parent.GetFoldersAsync().FirstOrDefaultAsync();
+        var instance2 = await parent.GetFoldersAsync().FirstOrDefaultAsync();
+        
+        if (instance1 is null || instance2 is null)
+            return;
+
+        if (instance1 is not ILastAccessedAt { LastAccessedAt: IModifiableStorageProperty<DateTime?> prop1 })
+            return;
+        
+        if (instance2 is not ILastAccessedAt instance2Prop)
+            return;
+
+        var initialValue = await instance2Prop.LastAccessedAt.GetValueAsync(CancellationToken.None);
+        var newValue = DateTime.Now.AddDays(-7);
+        
+        await prop1.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await instance2Prop.LastAccessedAt.GetValueAsync(CancellationToken.None);
+        
+        Assert.IsNotNull(retrieved);
+        Assert.AreNotEqual(initialValue, retrieved, $"instance2 should see updated value. Initial={initialValue:O}, Retrieved={retrieved:O}, Expected={newValue:O}");
+        Assert.AreEqual(newValue.Year, retrieved.Value.Year);
+        Assert.AreEqual(newValue.Month, retrieved.Value.Month);
+        Assert.AreEqual(newValue.Day, retrieved.Value.Day);
+    }
+
+    [TestMethod]
+    public async Task Folder_LastAccessedAtOffset_UpdateValueAsync_PersistsChange()
+    {
+        var parent = await CreateModifiableFolderWithItems(0, 1);
+        var instance1 = await parent.GetFoldersAsync().FirstOrDefaultAsync();
+        var instance2 = await parent.GetFoldersAsync().FirstOrDefaultAsync();
+        
+        if (instance1 is null || instance2 is null)
+            return;
+
+        if (instance1 is not ILastAccessedAtOffset { LastAccessedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop1 })
+            return;
+        
+        if (instance2 is not ILastAccessedAtOffset instance2Prop)
+            return;
+
+        var initialValue = await instance2Prop.LastAccessedAtOffset.GetValueAsync(CancellationToken.None);
+        var newValue = DateTimeOffset.Now.AddDays(-7);
+        
+        await prop1.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await instance2Prop.LastAccessedAtOffset.GetValueAsync(CancellationToken.None);
+        
+        Assert.IsNotNull(retrieved);
+        Assert.AreNotEqual(initialValue, retrieved, $"instance2 should see updated value. Initial={initialValue:O}, Retrieved={retrieved:O}, Expected={newValue:O}");
+        Assert.AreEqual(newValue.UtcDateTime.Year, retrieved.Value.UtcDateTime.Year);
+        Assert.AreEqual(newValue.UtcDateTime.Month, retrieved.Value.UtcDateTime.Month);
+        Assert.AreEqual(newValue.UtcDateTime.Day, retrieved.Value.UtcDateTime.Day);
+    }
+
+    [TestMethod]
+    public async Task Folder_LastModifiedAt_UpdateValueAsync_PersistsChange()
+    {
+        var parent = await CreateModifiableFolderWithItems(0, 1);
+        var instance1 = await parent.GetFoldersAsync().FirstOrDefaultAsync();
+        var instance2 = await parent.GetFoldersAsync().FirstOrDefaultAsync();
+        
+        if (instance1 is null || instance2 is null)
+            return;
+
+        if (instance1 is not ILastModifiedAt { LastModifiedAt: IModifiableStorageProperty<DateTime?> prop1 })
+            return;
+        
+        if (instance2 is not ILastModifiedAt instance2Prop)
+            return;
+
+        var initialValue = await instance2Prop.LastModifiedAt.GetValueAsync(CancellationToken.None);
+        var newValue = DateTime.Now.AddDays(-7);
+        
+        await prop1.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await instance2Prop.LastModifiedAt.GetValueAsync(CancellationToken.None);
+        
+        Assert.IsNotNull(retrieved);
+        Assert.AreNotEqual(initialValue, retrieved, $"instance2 should see updated value. Initial={initialValue:O}, Retrieved={retrieved:O}, Expected={newValue:O}");
+        Assert.AreEqual(newValue.Year, retrieved.Value.Year);
+        Assert.AreEqual(newValue.Month, retrieved.Value.Month);
+        Assert.AreEqual(newValue.Day, retrieved.Value.Day);
+    }
+
+    [TestMethod]
+    public async Task Folder_LastModifiedAtOffset_UpdateValueAsync_PersistsChange()
+    {
+        var parent = await CreateModifiableFolderWithItems(0, 1);
+        var instance1 = await parent.GetFoldersAsync().FirstOrDefaultAsync();
+        var instance2 = await parent.GetFoldersAsync().FirstOrDefaultAsync();
+        
+        if (instance1 is null || instance2 is null)
+            return;
+
+        if (instance1 is not ILastModifiedAtOffset { LastModifiedAtOffset: IModifiableStorageProperty<DateTimeOffset?> prop1 })
+            return;
+        
+        if (instance2 is not ILastModifiedAtOffset instance2Prop)
+            return;
+
+        var initialValue = await instance2Prop.LastModifiedAtOffset.GetValueAsync(CancellationToken.None);
+        var newValue = DateTimeOffset.Now.AddDays(-7);
+        
+        await prop1.UpdateValueAsync(newValue, CancellationToken.None);
+
+        var retrieved = await instance2Prop.LastModifiedAtOffset.GetValueAsync(CancellationToken.None);
+        
+        Assert.IsNotNull(retrieved);
+        Assert.AreNotEqual(initialValue, retrieved, $"instance2 should see updated value. Initial={initialValue:O}, Retrieved={retrieved:O}, Expected={newValue:O}");
+        Assert.AreEqual(newValue.UtcDateTime.Year, retrieved.Value.UtcDateTime.Year);
+        Assert.AreEqual(newValue.UtcDateTime.Month, retrieved.Value.UtcDateTime.Month);
+        Assert.AreEqual(newValue.UtcDateTime.Day, retrieved.Value.UtcDateTime.Day);
+    }
+}

--- a/src/CommonIModifiableFolderTests.ImplicitTimestampUpdates.cs
+++ b/src/CommonIModifiableFolderTests.ImplicitTimestampUpdates.cs
@@ -1,0 +1,428 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OwlCore.Storage.CommonTests;
+
+/// <summary>
+/// Tests for implicit timestamp updates that occur as side effects of file/folder operations.
+/// </summary>
+public abstract partial class CommonIModifiableFolderTests
+{
+    /// <summary>
+    /// Tests whether opening a file for read updates the file's LastAccessedAt timestamp.
+    /// </summary>
+    [TestMethod]
+    public async Task OpenFileRead_UpdatesLastAccessedAt()
+    {
+        if (LastAccessedAtUpdateBehavior == PropertyUpdateBehavior.Never)
+            return;
+
+        var folder = await CreateModifiableFolderWithItems(1, 0);
+        var file = await folder.GetFilesAsync().FirstAsync();
+
+        if (file is not ILastAccessedAt lastAccessedAtFile)
+            return;
+
+        // Set LastAccessedAt to the past
+        var oldLastAccessedAt = DateTime.UtcNow.AddDays(-7);
+        if (lastAccessedAtFile.LastAccessedAt is IModifiableStorageProperty<DateTime?> modifiableProp)
+        {
+            try { await modifiableProp.UpdateValueAsync(oldLastAccessedAt, CancellationToken.None); }
+            catch { return; } // Can't set timestamp, nothing meaningful to test
+        }
+        else
+        {
+            return; // Read-only LastAccessedAt, can't backdate to test
+        }
+
+        // Capture before value
+        var before = await lastAccessedAtFile.LastAccessedAt.GetValueAsync(CancellationToken.None);
+
+        // Open and read the file, then close it
+        {
+            using var stream = await file.OpenReadAsync();
+            var buffer = new byte[1];
+            _ = await stream.ReadAsync(buffer, 0, 1);
+        }
+
+        // Capture after value (after stream is closed)
+        var after = await lastAccessedAtFile.LastAccessedAt.GetValueAsync(CancellationToken.None);
+
+        switch (LastAccessedAtUpdateBehavior)
+        {
+            case PropertyUpdateBehavior.Immediate:
+                Assert.IsTrue(!AreTimestampsEqual(before, after), 
+                    $"LastAccessedAt should update immediately after file read. Before={before:O}, After={after:O}");
+                break;
+
+            case PropertyUpdateBehavior.Eventual:
+                // For eventual updates, we can't strictly assert - the value may or may not have changed yet
+                // Just verify we can read the value without error
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Tests whether opening a file for write updates the file's LastAccessedAt timestamp.
+    /// </summary>
+    [TestMethod]
+    public async Task OpenFileWrite_UpdatesLastAccessedAt()
+    {
+        if (LastAccessedAtUpdateBehavior == PropertyUpdateBehavior.Never)
+            return;
+
+        var folder = await CreateModifiableFolderWithItems(1, 0);
+        var file = await folder.GetFilesAsync().FirstAsync();
+
+        if (file is not ILastAccessedAt lastAccessedAtFile)
+            return;
+
+        // Set LastAccessedAt to the past
+        var oldLastAccessedAt = DateTime.UtcNow.AddDays(-7);
+        if (lastAccessedAtFile.LastAccessedAt is IModifiableStorageProperty<DateTime?> modifiableProp)
+        {
+            try { await modifiableProp.UpdateValueAsync(oldLastAccessedAt, CancellationToken.None); }
+            catch { return; } // Can't set timestamp, nothing meaningful to test
+        }
+        else
+        {
+            return; // Read-only LastAccessedAt, can't backdate to test
+        }
+
+        // Capture before value
+        var before = await lastAccessedAtFile.LastAccessedAt.GetValueAsync(CancellationToken.None);
+
+        // Open for write, then close it
+        {
+            using var stream = await file.OpenWriteAsync();
+            await stream.WriteAsync(new byte[] { 0x42 }, 0, 1);
+        }
+
+        // Capture after value (after stream is closed)
+        var after = await lastAccessedAtFile.LastAccessedAt.GetValueAsync(CancellationToken.None);
+
+        switch (LastAccessedAtUpdateBehavior)
+        {
+            case PropertyUpdateBehavior.Immediate:
+                Assert.IsTrue(!AreTimestampsEqual(before, after), 
+                    $"LastAccessedAt should update immediately after file write. Before={before:O}, After={after:O}");
+                break;
+
+            case PropertyUpdateBehavior.Eventual:
+                // For eventual updates, we can't strictly assert
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Tests whether writing to a file updates the file's LastModifiedAt timestamp.
+    /// </summary>
+    [TestMethod]
+    public async Task WriteFile_UpdatesLastModifiedAt()
+    {
+        if (LastModifiedAtUpdateBehavior == PropertyUpdateBehavior.Never)
+            return;
+
+        var folder = await CreateModifiableFolderWithItems(1, 0);
+        var file = await folder.GetFilesAsync().FirstAsync();
+
+        if (file is not ILastModifiedAt lastModifiedAtFile)
+            return;
+
+        // Set LastModifiedAt to the past
+        var oldLastModifiedAt = DateTime.UtcNow.AddDays(-7);
+        if (lastModifiedAtFile.LastModifiedAt is IModifiableStorageProperty<DateTime?> modifiableProp)
+        {
+            try { await modifiableProp.UpdateValueAsync(oldLastModifiedAt, CancellationToken.None); }
+            catch { return; } // Can't set timestamp, nothing meaningful to test
+        }
+        else
+        {
+            return; // Read-only LastModifiedAt, can't backdate to test
+        }
+
+        // Capture before value
+        var before = await lastModifiedAtFile.LastModifiedAt.GetValueAsync(CancellationToken.None);
+
+        // Write to the file, then close it
+        {
+            using var stream = await file.OpenWriteAsync();
+            await stream.WriteAsync(new byte[] { 0x42 }, 0, 1);
+        }
+
+        // Capture after value (after stream is closed)
+        var after = await lastModifiedAtFile.LastModifiedAt.GetValueAsync(CancellationToken.None);
+
+        switch (LastModifiedAtUpdateBehavior)
+        {
+            case PropertyUpdateBehavior.Immediate:
+                Assert.IsTrue(!AreTimestampsEqual(before, after), 
+                    $"LastModifiedAt should update immediately after file write. Before={before:O}, After={after:O}");
+                break;
+
+            case PropertyUpdateBehavior.Eventual:
+                // For eventual updates, we can't strictly assert
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Tests whether iterating folder contents updates the folder's LastAccessedAt timestamp.
+    /// </summary>
+    [TestMethod]
+    public async Task FolderIteration_UpdatesLastAccessedAt()
+    {
+        if (LastAccessedAtUpdateBehavior == PropertyUpdateBehavior.Never)
+            return;
+
+        var folder = await CreateModifiableFolderWithItems(1, 0);
+
+        if (folder is not ILastAccessedAt lastAccessedAtFolder)
+            return;
+
+        // Set LastAccessedAt to the past
+        var oldLastAccessedAt = DateTime.UtcNow.AddDays(-7);
+        if (lastAccessedAtFolder.LastAccessedAt is IModifiableStorageProperty<DateTime?> modifiableProp)
+        {
+            try { await modifiableProp.UpdateValueAsync(oldLastAccessedAt, CancellationToken.None); }
+            catch { return; } // Can't set timestamp, nothing meaningful to test
+        }
+        else
+        {
+            return; // Read-only LastAccessedAt, can't backdate to test
+        }
+
+        // Capture before value
+        var before = await lastAccessedAtFolder.LastAccessedAt.GetValueAsync(CancellationToken.None);
+
+        // Iterate folder contents
+        await foreach (var item in folder.GetItemsAsync())
+        {
+            _ = item.Name; // Force enumeration
+        }
+
+        // Capture after value
+        var after = await lastAccessedAtFolder.LastAccessedAt.GetValueAsync(CancellationToken.None);
+
+        switch (LastAccessedAtUpdateBehavior)
+        {
+            case PropertyUpdateBehavior.Immediate:
+                Assert.IsTrue(!AreTimestampsEqual(before, after), 
+                    $"LastAccessedAt should update immediately after folder iteration. Before={before:O}, After={after:O}");
+                break;
+
+            case PropertyUpdateBehavior.Eventual:
+                // For eventual updates, we can't strictly assert
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Tests whether creating a file in a folder updates the folder's LastModifiedAt timestamp.
+    /// </summary>
+    [TestMethod]
+    public async Task CreateFileInFolder_UpdatesFolderLastModifiedAt()
+    {
+        if (LastModifiedAtUpdateBehavior == PropertyUpdateBehavior.Never)
+            return;
+
+        var folder = await CreateModifiableFolderWithItems(0, 0);
+
+        if (folder is not ILastModifiedAt lastModifiedAtFolder)
+            return;
+
+        // Set LastModifiedAt to the past
+        var oldLastModifiedAt = DateTime.UtcNow.AddDays(-7);
+        if (lastModifiedAtFolder.LastModifiedAt is IModifiableStorageProperty<DateTime?> modifiableProp)
+        {
+            try { await modifiableProp.UpdateValueAsync(oldLastModifiedAt, CancellationToken.None); }
+            catch { return; } // Can't set timestamp, nothing meaningful to test
+        }
+        else
+        {
+            return; // Read-only LastModifiedAt, can't backdate to test
+        }
+
+        // Capture before value
+        var before = await lastModifiedAtFolder.LastModifiedAt.GetValueAsync(CancellationToken.None);
+
+        // Create a file in the folder
+        await folder.CreateFileAsync("test_file.txt");
+
+        // Capture after value
+        var after = await lastModifiedAtFolder.LastModifiedAt.GetValueAsync(CancellationToken.None);
+
+        switch (LastModifiedAtUpdateBehavior)
+        {
+            case PropertyUpdateBehavior.Immediate:
+                Assert.IsTrue(!AreTimestampsEqual(before, after), 
+                    $"LastModifiedAt should update immediately after creating file in folder. Before={before:O}, After={after:O}");
+                break;
+
+            case PropertyUpdateBehavior.Eventual:
+                // For eventual updates, we can't strictly assert
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Tests whether creating a subfolder updates the parent folder's LastModifiedAt timestamp.
+    /// </summary>
+    [TestMethod]
+    public async Task CreateFolderInFolder_UpdatesFolderLastModifiedAt()
+    {
+        if (LastModifiedAtUpdateBehavior == PropertyUpdateBehavior.Never)
+            return;
+
+        var folder = await CreateModifiableFolderWithItems(0, 0);
+
+        if (folder is not ILastModifiedAt lastModifiedAtFolder)
+            return;
+
+        // Set LastModifiedAt to the past
+        var oldLastModifiedAt = DateTime.UtcNow.AddDays(-7);
+        if (lastModifiedAtFolder.LastModifiedAt is IModifiableStorageProperty<DateTime?> modifiableProp)
+        {
+            try { await modifiableProp.UpdateValueAsync(oldLastModifiedAt, CancellationToken.None); }
+            catch { return; } // Can't set timestamp, nothing meaningful to test
+        }
+        else
+        {
+            return; // Read-only LastModifiedAt, can't backdate to test
+        }
+
+        // Capture before value
+        var before = await lastModifiedAtFolder.LastModifiedAt.GetValueAsync(CancellationToken.None);
+
+        // Create a subfolder
+        await folder.CreateFolderAsync("test_subfolder");
+
+        // Capture after value
+        var after = await lastModifiedAtFolder.LastModifiedAt.GetValueAsync(CancellationToken.None);
+
+        switch (LastModifiedAtUpdateBehavior)
+        {
+            case PropertyUpdateBehavior.Immediate:
+                Assert.IsTrue(!AreTimestampsEqual(before, after), 
+                    $"LastModifiedAt should update immediately after creating subfolder. Before={before:O}, After={after:O}");
+                break;
+
+            case PropertyUpdateBehavior.Eventual:
+                // For eventual updates, we can't strictly assert
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Tests whether deleting a file from a folder updates the folder's LastModifiedAt timestamp.
+    /// </summary>
+    [TestMethod]
+    public async Task DeleteFileFromFolder_UpdatesFolderLastModifiedAt()
+    {
+        if (LastModifiedAtUpdateBehavior == PropertyUpdateBehavior.Never)
+            return;
+
+        var folder = await CreateModifiableFolderWithItems(1, 0);
+        var file = await folder.GetFilesAsync().FirstAsync();
+
+        if (folder is not ILastModifiedAt lastModifiedAtFolder)
+            return;
+
+        // Set LastModifiedAt to the past
+        var oldLastModifiedAt = DateTime.UtcNow.AddDays(-7);
+        if (lastModifiedAtFolder.LastModifiedAt is IModifiableStorageProperty<DateTime?> modifiableProp)
+        {
+            try { await modifiableProp.UpdateValueAsync(oldLastModifiedAt, CancellationToken.None); }
+            catch { return; } // Can't set timestamp, nothing meaningful to test
+        }
+        else
+        {
+            return; // Read-only LastModifiedAt, can't backdate to test
+        }
+
+        // Capture before value
+        var before = await lastModifiedAtFolder.LastModifiedAt.GetValueAsync(CancellationToken.None);
+
+        // Delete the file
+        await folder.DeleteAsync(file);
+
+        // Capture after value
+        var after = await lastModifiedAtFolder.LastModifiedAt.GetValueAsync(CancellationToken.None);
+
+        switch (LastModifiedAtUpdateBehavior)
+        {
+            case PropertyUpdateBehavior.Immediate:
+                Assert.IsTrue(!AreTimestampsEqual(before, after), 
+                    $"LastModifiedAt should update immediately after deleting file from folder. Before={before:O}, After={after:O}");
+                break;
+
+            case PropertyUpdateBehavior.Eventual:
+                // For eventual updates, we can't strictly assert
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Tests whether deleting a subfolder updates the parent folder's LastModifiedAt timestamp.
+    /// </summary>
+    [TestMethod]
+    public async Task DeleteFolderFromFolder_UpdatesFolderLastModifiedAt()
+    {
+        if (LastModifiedAtUpdateBehavior == PropertyUpdateBehavior.Never)
+            return;
+
+        var folder = await CreateModifiableFolderWithItems(0, 1);
+        var subfolder = await folder.GetFoldersAsync().FirstAsync();
+
+        if (folder is not ILastModifiedAt lastModifiedAtFolder)
+            return;
+
+        // Set LastModifiedAt to the past
+        var oldLastModifiedAt = DateTime.UtcNow.AddDays(-7);
+        if (lastModifiedAtFolder.LastModifiedAt is IModifiableStorageProperty<DateTime?> modifiableProp)
+        {
+            try { await modifiableProp.UpdateValueAsync(oldLastModifiedAt, CancellationToken.None); }
+            catch { return; } // Can't set timestamp, nothing meaningful to test
+        }
+        else
+        {
+            return; // Read-only LastModifiedAt, can't backdate to test
+        }
+
+        // Capture before value
+        var before = await lastModifiedAtFolder.LastModifiedAt.GetValueAsync(CancellationToken.None);
+
+        // Delete the subfolder
+        await folder.DeleteAsync(subfolder);
+
+        // Capture after value
+        var after = await lastModifiedAtFolder.LastModifiedAt.GetValueAsync(CancellationToken.None);
+
+        switch (LastModifiedAtUpdateBehavior)
+        {
+            case PropertyUpdateBehavior.Immediate:
+                Assert.IsTrue(!AreTimestampsEqual(before, after), 
+                    $"LastModifiedAt should update immediately after deleting subfolder. Before={before:O}, After={after:O}");
+                break;
+
+            case PropertyUpdateBehavior.Eventual:
+                // For eventual updates, we can't strictly assert
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Compares two DateTime values with tolerance for filesystem precision differences.
+    /// </summary>
+    private static bool AreTimestampsEqual(DateTime? source, DateTime? dest)
+    {
+        if (source is null || dest is null)
+            return false;
+        
+        // Allow 2 second tolerance for filesystem precision differences
+        return Math.Abs((source.Value - dest.Value).TotalSeconds) < 2;
+    }
+}

--- a/src/CommonIModifiableFolderTests.PropertyWatcher.cs
+++ b/src/CommonIModifiableFolderTests.PropertyWatcher.cs
@@ -1,0 +1,441 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OwlCore.Storage.CommonTests;
+
+/// <summary>
+/// Tests for <see cref="IStoragePropertyWatcher{T}"/> implementations.
+/// These tests verify that property watchers correctly detect and report property changes.
+/// </summary>
+public abstract partial class CommonIModifiableFolderTests
+{
+    /// <summary>
+    /// Tests that a mutable property returns a non-null watcher.
+    /// </summary>
+    [TestMethod]
+    public async Task PropertyWatcher_GetWatcherAsync_ReturnsNonNullWatcher()
+    {
+        var folder = await CreateModifiableFolderWithItems(1, 0);
+        var file = await folder.GetFilesAsync().FirstAsync();
+
+        // Find a mutable property to test
+        IStoragePropertyWatcher<DateTime?>? watcher = null;
+
+        if (file is ILastModifiedAt { LastModifiedAt: IMutableStorageProperty<DateTime?> mutableProp })
+        {
+            watcher = await mutableProp.GetWatcherAsync(CancellationToken.None);
+        }
+
+        if (watcher is null)
+        {
+            // No mutable properties available
+            return;
+        }
+
+        try
+        {
+            Assert.IsNotNull(watcher, "GetWatcherAsync should return a non-null watcher");
+            Assert.IsNotNull(watcher.Property, "Watcher.Property should reference the watched property");
+        }
+        finally
+        {
+            watcher.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Tests that ValueUpdated fires when the timestamp is changed externally (via the property interface).
+    /// </summary>
+    [TestMethod]
+    public async Task PropertyWatcher_ValueUpdated_FiresOnPropertyUpdate()
+    {
+        var folder = await CreateModifiableFolderWithItems(1, 0);
+        var file = await folder.GetFilesAsync().FirstAsync();
+
+        // Need a modifiable + mutable property
+        if (file is not ILastModifiedAt { LastModifiedAt: IModifiableStorageProperty<DateTime?> modifiableProp })
+            return;
+
+        if (modifiableProp is not IMutableStorageProperty<DateTime?> mutableProp)
+            return;
+
+        var watcher = await mutableProp.GetWatcherAsync(CancellationToken.None);
+        var eventFired = new TaskCompletionSource<DateTime?>();
+        var eventCount = 0;
+
+        watcher.ValueUpdated += (sender, newValue) =>
+        {
+            eventCount++;
+            eventFired.TrySetResult(newValue);
+        };
+
+        try
+        {
+            // Change the property value
+            var newTime = DateTime.UtcNow.AddDays(-10);
+            await modifiableProp.UpdateValueAsync(newTime, CancellationToken.None);
+
+            // Wait for event or timeout
+            var timeoutTask = Task.Delay(3000);
+            var completedTask = await Task.WhenAny(eventFired.Task, timeoutTask);
+
+            Assert.IsTrue(eventFired.Task.IsCompleted, "ValueUpdated should fire when property is updated");
+            Assert.IsTrue(eventCount >= 1, "ValueUpdated should fire at least once");
+
+            // Verify the value is approximately correct (within 2 seconds tolerance)
+            var reportedValue = await eventFired.Task;
+            Assert.IsNotNull(reportedValue, "ValueUpdated should provide the new value");
+            Assert.IsTrue(Math.Abs((reportedValue.Value.ToUniversalTime() - newTime).TotalSeconds) < 2,
+                $"ValueUpdated should report the correct new value. Expected={newTime:O}, Actual={reportedValue:O}");
+        }
+        finally
+        {
+            watcher.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Tests that ValueUpdated fires when the file content is modified (which updates LastModifiedAt).
+    /// </summary>
+    [TestMethod]
+    public async Task PropertyWatcher_ValueUpdated_FiresOnContentChange()
+    {
+        var folder = await CreateModifiableFolderWithItems(1, 0);
+        var file = await folder.GetFilesAsync().FirstAsync();
+
+        if (file is not ILastModifiedAt { LastModifiedAt: IMutableStorageProperty<DateTime?> mutableProp })
+            return;
+
+        var watcher = await mutableProp.GetWatcherAsync(CancellationToken.None);
+        var eventFired = new TaskCompletionSource<DateTime?>();
+
+        watcher.ValueUpdated += (sender, newValue) =>
+        {
+            eventFired.TrySetResult(newValue);
+        };
+
+        try
+        {
+            // Capture original value
+            var originalValue = await mutableProp.GetValueAsync(CancellationToken.None);
+
+            // Modify file content (should update LastModifiedAt)
+            using (var stream = await file.OpenStreamAsync(FileAccess.Write, CancellationToken.None))
+            {
+                var data = Encoding.UTF8.GetBytes("Modified content at " + DateTime.UtcNow);
+                await stream.WriteAsync(data, 0, data.Length);
+            }
+
+            // Wait for event or timeout
+            var timeoutTask = Task.Delay(3000);
+            var completedTask = await Task.WhenAny(eventFired.Task, timeoutTask);
+
+            Assert.IsTrue(eventFired.Task.IsCompleted, "ValueUpdated should fire when file content changes");
+
+            var reportedValue = await eventFired.Task;
+            Assert.IsNotNull(reportedValue, "ValueUpdated should provide the new value");
+            Assert.IsTrue(reportedValue > originalValue, "LastModifiedAt should be newer after content change");
+        }
+        finally
+        {
+            watcher.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Tests that disposing the watcher stops events from being raised.
+    /// </summary>
+    [TestMethod]
+    public async Task PropertyWatcher_Dispose_StopsEvents()
+    {
+        var folder = await CreateModifiableFolderWithItems(1, 0);
+        var file = await folder.GetFilesAsync().FirstAsync();
+
+        if (file is not ILastModifiedAt { LastModifiedAt: IModifiableStorageProperty<DateTime?> modifiableProp })
+            return;
+
+        if (modifiableProp is not IMutableStorageProperty<DateTime?> mutableProp)
+            return;
+
+        var watcher = await mutableProp.GetWatcherAsync(CancellationToken.None);
+        var eventCount = 0;
+
+        watcher.ValueUpdated += (sender, newValue) =>
+        {
+            eventCount++;
+        };
+
+        // Dispose the watcher
+        watcher.Dispose();
+
+        // Change the property value after disposal
+        var newTime = DateTime.UtcNow.AddDays(-5);
+        await modifiableProp.UpdateValueAsync(newTime, CancellationToken.None);
+
+        // Wait a bit to ensure no events fire
+        await Task.Delay(1000);
+
+        Assert.AreEqual(0, eventCount, "ValueUpdated should not fire after watcher is disposed");
+    }
+
+    /// <summary>
+    /// Tests that multiple watchers for the same property all receive events.
+    /// </summary>
+    [TestMethod]
+    public async Task PropertyWatcher_MultipleWatchers_AllReceiveEvents()
+    {
+        var folder = await CreateModifiableFolderWithItems(1, 0);
+        var file = await folder.GetFilesAsync().FirstAsync();
+
+        if (file is not ILastModifiedAt { LastModifiedAt: IModifiableStorageProperty<DateTime?> modifiableProp })
+            return;
+
+        if (modifiableProp is not IMutableStorageProperty<DateTime?> mutableProp)
+            return;
+
+        var watcher1 = await mutableProp.GetWatcherAsync(CancellationToken.None);
+        var watcher2 = await mutableProp.GetWatcherAsync(CancellationToken.None);
+
+        var event1Fired = new TaskCompletionSource<bool>();
+        var event2Fired = new TaskCompletionSource<bool>();
+
+        watcher1.ValueUpdated += (sender, newValue) => event1Fired.TrySetResult(true);
+        watcher2.ValueUpdated += (sender, newValue) => event2Fired.TrySetResult(true);
+
+        try
+        {
+            // Change the property value
+            var newTime = DateTime.UtcNow.AddDays(-10);
+            await modifiableProp.UpdateValueAsync(newTime, CancellationToken.None);
+
+            // Wait for both events
+            var timeoutTask = Task.Delay(3000);
+            await Task.WhenAny(Task.WhenAll(event1Fired.Task, event2Fired.Task), timeoutTask);
+
+            Assert.IsTrue(event1Fired.Task.IsCompleted, "First watcher should receive ValueUpdated");
+            Assert.IsTrue(event2Fired.Task.IsCompleted, "Second watcher should receive ValueUpdated");
+        }
+        finally
+        {
+            watcher1.Dispose();
+            watcher2.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Tests that multiple separate instances of the same property all receive events.
+    /// This forces the test to rely on the underlying storage system (e.g. filesystem events)
+    /// rather than local event aggregation on a single object instance.
+    /// </summary>
+    [TestMethod]
+    public async Task PropertyWatcher_CrossInstance_Notification()
+    {
+        var folder = await CreateModifiableFolderWithItems(1, 0);
+        
+        // Get the file twice, creating two separate "instances" representing the same resource
+        var fileInstance1 = await folder.GetFilesAsync().FirstAsync();
+        var fileInstance2 = await folder.GetFilesAsync().FirstAsync();
+
+        if (fileInstance1 is not ILastModifiedAt { LastModifiedAt: IMutableStorageProperty<DateTime?> mutableProp1 })
+            return;
+            
+        if (fileInstance2 is not ILastModifiedAt { LastModifiedAt: IModifiableStorageProperty<DateTime?> modifiableProp2 })
+            return;
+
+        // Watch on instance 1
+        var watcher1 = await mutableProp1.GetWatcherAsync(CancellationToken.None);
+        var eventFired = new TaskCompletionSource<DateTime?>();
+
+        watcher1.ValueUpdated += (sender, newValue) =>
+        {
+            eventFired.TrySetResult(newValue);
+        };
+
+        try
+        {
+            // Update on instance 2
+            var newTime = DateTime.UtcNow.AddDays(-10);
+            await modifiableProp2.UpdateValueAsync(newTime, CancellationToken.None);
+
+            // Wait for event on instance 1
+            var timeoutTask = Task.Delay(3000);
+            await Task.WhenAny(eventFired.Task, timeoutTask);
+
+            Assert.IsTrue(eventFired.Task.IsCompleted, "Watcher on separate instance should receive ValueUpdated");
+            
+            var reportedValue = await eventFired.Task;
+            Assert.IsNotNull(reportedValue, "ValueUpdated should provide the new value");
+            Assert.IsTrue(Math.Abs((reportedValue.Value.ToUniversalTime() - newTime).TotalSeconds) < 2,
+                $"ValueUpdated should report the correct new value. Expected={newTime:O}, Actual={reportedValue:O}");
+        }
+        finally
+        {
+            watcher1.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Tests that disposing one watcher doesn't affect other watchers.
+    /// </summary>
+    [TestMethod]
+    public async Task PropertyWatcher_DisposeOne_OthersStillWork()
+    {
+        var folder = await CreateModifiableFolderWithItems(1, 0);
+        var file = await folder.GetFilesAsync().FirstAsync();
+
+        if (file is not ILastModifiedAt { LastModifiedAt: IModifiableStorageProperty<DateTime?> modifiableProp })
+            return;
+
+        if (modifiableProp is not IMutableStorageProperty<DateTime?> mutableProp)
+            return;
+
+        var watcher1 = await mutableProp.GetWatcherAsync(CancellationToken.None);
+        var watcher2 = await mutableProp.GetWatcherAsync(CancellationToken.None);
+
+        var event1Count = 0;
+        var event2Fired = new TaskCompletionSource<bool>();
+
+        watcher1.ValueUpdated += (sender, newValue) => event1Count++;
+        watcher2.ValueUpdated += (sender, newValue) => event2Fired.TrySetResult(true);
+
+        // Dispose only the first watcher
+        watcher1.Dispose();
+
+        try
+        {
+            // Change the property value
+            var newTime = DateTime.UtcNow.AddDays(-10);
+            await modifiableProp.UpdateValueAsync(newTime, CancellationToken.None);
+
+            // Wait for event
+            var timeoutTask = Task.Delay(3000);
+            await Task.WhenAny(event2Fired.Task, timeoutTask);
+
+            Assert.AreEqual(0, event1Count, "Disposed watcher should not receive events");
+            Assert.IsTrue(event2Fired.Task.IsCompleted, "Non-disposed watcher should still receive events");
+        }
+        finally
+        {
+            watcher2.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Tests async disposal of watcher.
+    /// </summary>
+    [TestMethod]
+    public async Task PropertyWatcher_DisposeAsync_StopsEvents()
+    {
+        var folder = await CreateModifiableFolderWithItems(1, 0);
+        var file = await folder.GetFilesAsync().FirstAsync();
+
+        if (file is not ILastModifiedAt { LastModifiedAt: IModifiableStorageProperty<DateTime?> modifiableProp })
+            return;
+
+        if (modifiableProp is not IMutableStorageProperty<DateTime?> mutableProp)
+            return;
+
+        var watcher = await mutableProp.GetWatcherAsync(CancellationToken.None);
+        var eventCount = 0;
+
+        watcher.ValueUpdated += (sender, newValue) =>
+        {
+            eventCount++;
+        };
+
+        // Dispose asynchronously
+        await watcher.DisposeAsync();
+
+        // Change the property value after disposal
+        var newTime = DateTime.UtcNow.AddDays(-5);
+        await modifiableProp.UpdateValueAsync(newTime, CancellationToken.None);
+
+        // Wait a bit to ensure no events fire
+        await Task.Delay(1000);
+
+        Assert.AreEqual(0, eventCount, "ValueUpdated should not fire after watcher is disposed asynchronously");
+    }
+
+    /// <summary>
+    /// Tests that CreatedAt property watcher works (if supported).
+    /// </summary>
+    [TestMethod]
+    public async Task PropertyWatcher_CreatedAt_ValueUpdated_Fires()
+    {
+        var folder = await CreateModifiableFolderWithItems(1, 0);
+        var file = await folder.GetFilesAsync().FirstAsync();
+
+        if (file is not ICreatedAt { CreatedAt: IModifiableStorageProperty<DateTime?> modifiableProp })
+            return;
+
+        if (modifiableProp is not IMutableStorageProperty<DateTime?> mutableProp)
+            return;
+
+        var watcher = await mutableProp.GetWatcherAsync(CancellationToken.None);
+        var eventFired = new TaskCompletionSource<DateTime?>();
+
+        watcher.ValueUpdated += (sender, newValue) =>
+        {
+            eventFired.TrySetResult(newValue);
+        };
+
+        try
+        {
+            var newTime = DateTime.UtcNow.AddDays(-30);
+            await modifiableProp.UpdateValueAsync(newTime, CancellationToken.None);
+
+            var timeoutTask = Task.Delay(3000);
+            await Task.WhenAny(eventFired.Task, timeoutTask);
+
+            Assert.IsTrue(eventFired.Task.IsCompleted, "CreatedAt watcher should fire ValueUpdated on change");
+        }
+        finally
+        {
+            watcher.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Tests that LastAccessedAt property watcher works (if supported).
+    /// </summary>
+    [TestMethod]
+    public async Task PropertyWatcher_LastAccessedAt_ValueUpdated_Fires()
+    {
+        var folder = await CreateModifiableFolderWithItems(1, 0);
+        var file = await folder.GetFilesAsync().FirstAsync();
+
+        if (file is not ILastAccessedAt { LastAccessedAt: IModifiableStorageProperty<DateTime?> modifiableProp })
+            return;
+
+        if (modifiableProp is not IMutableStorageProperty<DateTime?> mutableProp)
+            return;
+
+        var watcher = await mutableProp.GetWatcherAsync(CancellationToken.None);
+        var eventFired = new TaskCompletionSource<DateTime?>();
+
+        watcher.ValueUpdated += (sender, newValue) =>
+        {
+            eventFired.TrySetResult(newValue);
+        };
+
+        try
+        {
+            var newTime = DateTime.UtcNow.AddDays(-7);
+            await modifiableProp.UpdateValueAsync(newTime, CancellationToken.None);
+
+            var timeoutTask = Task.Delay(3000);
+            await Task.WhenAny(eventFired.Task, timeoutTask);
+
+            Assert.IsTrue(eventFired.Task.IsCompleted, "LastAccessedAt watcher should fire ValueUpdated on change");
+        }
+        finally
+        {
+            watcher.Dispose();
+        }
+    }
+}

--- a/src/CommonIModifiableFolderTests.cs
+++ b/src/CommonIModifiableFolderTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OwlCore.Extensions;
 using System.IO;
 using System.Threading.Tasks;
@@ -8,7 +8,7 @@ using System.Diagnostics;
 
 namespace OwlCore.Storage.CommonTests;
 
-public abstract class CommonIModifiableFolderTests : CommonIFolderTests
+public abstract partial class CommonIModifiableFolderTests : CommonIFolderTests
 {
     /// <summary>
     /// Creates a folder with items in it.
@@ -29,6 +29,32 @@ public abstract class CommonIModifiableFolderTests : CommonIFolderTests
     /// Creates a folder with items in it.
     /// </summary>
     public override async Task<IFolder> CreateFolderWithItems(int fileCount, int folderCount) => await CreateModifiableFolderWithItems(fileCount, folderCount);
+
+    /// <summary>
+    /// Creates a file in the given folder with a specific LastModifiedAt timestamp.
+    /// </summary>
+    /// <param name="folder">The folder to create the file in.</param>
+    /// <param name="lastModifiedAt">The last modified timestamp to apply.</param>
+    /// <returns>The created file, or null if the implementation doesn't support setting LastModifiedAt on created files.</returns>
+    /// <remarks>
+    /// Implementations must explicitly return null if they don't support setting LastModifiedAt on created files,
+    /// which signals the test should be skipped. This ensures gaps are surfaced rather than silently ignored.
+    /// </remarks>
+    public abstract Task<IFile?> CreateFileInFolderWithLastModifiedAtAsync(IModifiableFolder folder, DateTime lastModifiedAt);
+
+    /// <summary>
+    /// Creates a file in the given folder with specific timestamps.
+    /// </summary>
+    /// <param name="folder">The folder to create the file in.</param>
+    /// <param name="createdAt">The creation timestamp to apply, or null to skip.</param>
+    /// <param name="lastModifiedAt">The last modified timestamp to apply, or null to skip.</param>
+    /// <param name="lastAccessedAt">The last accessed timestamp to apply, or null to skip.</param>
+    /// <returns>The created file, or null if the implementation doesn't support setting timestamps on created files.</returns>
+    /// <remarks>
+    /// Implementations must explicitly return null if they don't support setting timestamps on created files,
+    /// which signals the test should be skipped. This ensures gaps are surfaced rather than silently ignored.
+    /// </remarks>
+    public abstract Task<IFile?> CreateFileInFolderWithTimestampsAsync(IModifiableFolder folder, DateTime? createdAt, DateTime? lastModifiedAt, DateTime? lastAccessedAt);
 
     [TestMethod]
     public async Task DeleteAsyncTest()

--- a/src/MockModifiableProperty.cs
+++ b/src/MockModifiableProperty.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OwlCore.Storage.CommonTests;
+
+/// <summary>
+/// A simple mock modifiable property for testing.
+/// </summary>
+public class MockModifiableProperty<T> : IModifiableStorageProperty<T>
+{
+    private readonly Func<T> _getter;
+    private readonly Action<T> _setter;
+
+    public MockModifiableProperty(string id, string name, Func<T> getter, Action<T> setter)
+    {
+        Id = id;
+        Name = name;
+        _getter = getter;
+        _setter = setter;
+    }
+
+    public string Id { get; }
+    public string Name { get; }
+
+    public Task<T> GetValueAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(_getter());
+
+    public Task UpdateValueAsync(T value, CancellationToken cancellationToken = default)
+    {
+        _setter(value);
+        return Task.CompletedTask;
+    }
+
+    public Task<IStoragePropertyWatcher<T>> GetWatcherAsync(CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Mock does not support watchers");
+}
+
+/// <summary>
+/// Concrete mock property implementations for timestamp interfaces.
+/// </summary>
+public class MockCreatedAtProperty : MockModifiableProperty<DateTime?>, IModifiableCreatedAtProperty
+{
+    public MockCreatedAtProperty(string id, Func<DateTime?> getter, Action<DateTime?> setter) 
+        : base(id, nameof(ICreatedAt.CreatedAt), getter, setter) { }
+}
+
+public class MockCreatedAtOffsetProperty : MockModifiableProperty<DateTimeOffset?>, IModifiableCreatedAtOffsetProperty
+{
+    public MockCreatedAtOffsetProperty(string id, Func<DateTimeOffset?> getter, Action<DateTimeOffset?> setter) 
+        : base(id, nameof(ICreatedAtOffset.CreatedAtOffset), getter, setter) { }
+}
+
+public class MockLastModifiedAtProperty : MockModifiableProperty<DateTime?>, IModifiableLastModifiedAtProperty
+{
+    public MockLastModifiedAtProperty(string id, Func<DateTime?> getter, Action<DateTime?> setter) 
+        : base(id, nameof(ILastModifiedAt.LastModifiedAt), getter, setter) { }
+}
+
+public class MockLastModifiedAtOffsetProperty : MockModifiableProperty<DateTimeOffset?>, IModifiableLastModifiedAtOffsetProperty
+{
+    public MockLastModifiedAtOffsetProperty(string id, Func<DateTimeOffset?> getter, Action<DateTimeOffset?> setter) 
+        : base(id, nameof(ILastModifiedAtOffset.LastModifiedAtOffset), getter, setter) { }
+}
+
+public class MockLastAccessedAtProperty : MockModifiableProperty<DateTime?>, IModifiableLastAccessedAtProperty
+{
+    public MockLastAccessedAtProperty(string id, Func<DateTime?> getter, Action<DateTime?> setter) 
+        : base(id, nameof(ILastAccessedAt.LastAccessedAt), getter, setter) { }
+}
+
+public class MockLastAccessedAtOffsetProperty : MockModifiableProperty<DateTimeOffset?>, IModifiableLastAccessedAtOffsetProperty
+{
+    public MockLastAccessedAtOffsetProperty(string id, Func<DateTimeOffset?> getter, Action<DateTimeOffset?> setter) 
+        : base(id, nameof(ILastAccessedAtOffset.LastAccessedAtOffset), getter, setter) { }
+}

--- a/src/MockStorageFile.cs
+++ b/src/MockStorageFile.cs
@@ -1,0 +1,155 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OwlCore.Storage.CommonTests;
+
+/// <summary>
+/// A mock file implementation for testing cross-implementation scenarios.
+/// Supports configurable timestamp property support.
+/// </summary>
+public class MockStorageFile : IChildFile, ICreatedAt, ICreatedAtOffset, ILastModifiedAt, ILastModifiedAtOffset, ILastAccessedAt, ILastAccessedAtOffset
+{
+    private readonly MockStorageFolder _parent;
+    private byte[] _content;
+
+    public MockStorageFile(string name, MockStorageFolder parent, byte[]? content = null)
+    {
+        Name = name;
+        _parent = parent;
+        _content = content ?? Array.Empty<byte>();
+
+        var now = DateTimeOffset.UtcNow;
+        CreatedAtValue = now;
+        LastModifiedAtValue = now;
+        LastAccessedAtValue = now;
+
+        CreatedAt = new MockCreatedAtProperty(
+            $"{Id}/{nameof(ICreatedAt.CreatedAt)}",
+            () => CreatedAtValue?.LocalDateTime,
+            v => CreatedAtValue = v.HasValue ? new DateTimeOffset(v.Value) : null);
+
+        CreatedAtOffset = new MockCreatedAtOffsetProperty(
+            $"{Id}/{nameof(ICreatedAtOffset.CreatedAtOffset)}",
+            () => CreatedAtValue,
+            v => CreatedAtValue = v);
+
+        LastModifiedAt = new MockLastModifiedAtProperty(
+            $"{Id}/{nameof(ILastModifiedAt.LastModifiedAt)}",
+            () => LastModifiedAtValue?.LocalDateTime,
+            v => LastModifiedAtValue = v.HasValue ? new DateTimeOffset(v.Value) : null);
+
+        LastModifiedAtOffset = new MockLastModifiedAtOffsetProperty(
+            $"{Id}/{nameof(ILastModifiedAtOffset.LastModifiedAtOffset)}",
+            () => LastModifiedAtValue,
+            v => LastModifiedAtValue = v);
+
+        LastAccessedAt = new MockLastAccessedAtProperty(
+            $"{Id}/{nameof(ILastAccessedAt.LastAccessedAt)}",
+            () => LastAccessedAtValue?.LocalDateTime,
+            v => LastAccessedAtValue = v.HasValue ? new DateTimeOffset(v.Value) : null);
+
+        LastAccessedAtOffset = new MockLastAccessedAtOffsetProperty(
+            $"{Id}/{nameof(ILastAccessedAtOffset.LastAccessedAtOffset)}",
+            () => LastAccessedAtValue,
+            v => LastAccessedAtValue = v);
+    }
+
+    public string Id => $"{_parent.Id}/{Name}";
+    public string Name { get; }
+
+    public DateTimeOffset? CreatedAtValue { get; set; }
+    public DateTimeOffset? LastModifiedAtValue { get; set; }
+    public DateTimeOffset? LastAccessedAtValue { get; set; }
+
+    public ICreatedAtProperty CreatedAt { get; }
+    public ICreatedAtOffsetProperty CreatedAtOffset { get; }
+    public ILastModifiedAtProperty LastModifiedAt { get; }
+    public ILastModifiedAtOffsetProperty LastModifiedAtOffset { get; }
+    public ILastAccessedAtProperty LastAccessedAt { get; }
+    public ILastAccessedAtOffsetProperty LastAccessedAtOffset { get; }
+
+    public Task<IFolder?> GetParentAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IFolder?>(_parent);
+
+    public Task<Stream> OpenStreamAsync(FileAccess accessMode = FileAccess.Read, CancellationToken cancellationToken = default)
+    {
+        LastAccessedAtValue = DateTimeOffset.UtcNow;
+
+        if (accessMode == FileAccess.Read)
+            return Task.FromResult<Stream>(new MemoryStream(_content, writable: false));
+
+        // For write access, return a stream that captures writes
+        var stream = new MockWriteStream(_content, bytes =>
+        {
+            _content = bytes;
+            LastModifiedAtValue = DateTimeOffset.UtcNow;
+        });
+
+        return Task.FromResult<Stream>(stream);
+    }
+
+    internal void SetContent(byte[] content)
+    {
+        _content = content;
+    }
+
+    private class MockWriteStream : MemoryStream
+    {
+        private readonly Action<byte[]> _onDispose;
+
+        public MockWriteStream(byte[] initial, Action<byte[]> onDispose) : base()
+        {
+            Write(initial, 0, initial.Length);
+            Position = 0;
+            _onDispose = onDispose;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _onDispose(ToArray());
+            base.Dispose(disposing);
+        }
+    }
+}
+
+/// <summary>
+/// A mock file that has NO timestamp property support.
+/// Used for testing cross-implementation scenarios with partial property support.
+/// </summary>
+public class MockStorageFileNoTimestamps : IChildFile
+{
+    private readonly IFolder? _parent;
+    private byte[] _content;
+
+    public MockStorageFileNoTimestamps(string name, IFolder? parent, byte[]? content = null)
+    {
+        Name = name;
+        _parent = parent;
+        _content = content ?? Array.Empty<byte>();
+    }
+
+    public string Id => _parent != null ? $"{_parent.Id}/{Name}" : $"mock-no-ts://{Name}";
+    public string Name { get; }
+
+    public Task<IFolder?> GetParentAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(_parent);
+
+    public Task<Stream> OpenStreamAsync(FileAccess accessMode = FileAccess.Read, CancellationToken cancellationToken = default)
+    {
+        if (accessMode == FileAccess.Read)
+            return Task.FromResult<Stream>(new MemoryStream(_content, writable: false));
+
+        var stream = new MemoryStream();
+        stream.Write(_content, 0, _content.Length);
+        stream.Position = 0;
+        return Task.FromResult<Stream>(stream);
+    }
+
+    internal void SetContent(byte[] content)
+    {
+        _content = content;
+    }
+}

--- a/src/MockStorageFolder.cs
+++ b/src/MockStorageFolder.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OwlCore.Storage.CommonTests;
+
+/// <summary>
+/// A mock folder implementation for testing cross-implementation scenarios.
+/// Does NOT implement ICreateCopyOf or IMoveFrom, forcing fallback paths.
+/// </summary>
+public class MockStorageFolder : IModifiableFolder, IChildFolder, ICreatedAt, ICreatedAtOffset, ILastModifiedAt, ILastModifiedAtOffset, ILastAccessedAt, ILastAccessedAtOffset
+{
+    private readonly MockStorageFolder? _parent;
+    private readonly List<IStorableChild> _children = new();
+    private readonly bool _createFilesWithTimestamps;
+
+    public MockStorageFolder(string name, MockStorageFolder? parent = null, bool createFilesWithTimestamps = true)
+    {
+        Name = name;
+        _parent = parent;
+        _createFilesWithTimestamps = createFilesWithTimestamps;
+
+        var now = DateTimeOffset.UtcNow;
+        CreatedAtValue = now;
+        LastModifiedAtValue = now;
+        LastAccessedAtValue = now;
+
+        CreatedAt = new MockCreatedAtProperty(
+            $"{Id}/{nameof(ICreatedAt.CreatedAt)}",
+            () => CreatedAtValue?.LocalDateTime,
+            v => CreatedAtValue = v.HasValue ? new DateTimeOffset(v.Value) : null);
+
+        CreatedAtOffset = new MockCreatedAtOffsetProperty(
+            $"{Id}/{nameof(ICreatedAtOffset.CreatedAtOffset)}",
+            () => CreatedAtValue,
+            v => CreatedAtValue = v);
+
+        LastModifiedAt = new MockLastModifiedAtProperty(
+            $"{Id}/{nameof(ILastModifiedAt.LastModifiedAt)}",
+            () => LastModifiedAtValue?.LocalDateTime,
+            v => LastModifiedAtValue = v.HasValue ? new DateTimeOffset(v.Value) : null);
+
+        LastModifiedAtOffset = new MockLastModifiedAtOffsetProperty(
+            $"{Id}/{nameof(ILastModifiedAtOffset.LastModifiedAtOffset)}",
+            () => LastModifiedAtValue,
+            v => LastModifiedAtValue = v);
+
+        LastAccessedAt = new MockLastAccessedAtProperty(
+            $"{Id}/{nameof(ILastAccessedAt.LastAccessedAt)}",
+            () => LastAccessedAtValue?.LocalDateTime,
+            v => LastAccessedAtValue = v.HasValue ? new DateTimeOffset(v.Value) : null);
+
+        LastAccessedAtOffset = new MockLastAccessedAtOffsetProperty(
+            $"{Id}/{nameof(ILastAccessedAtOffset.LastAccessedAtOffset)}",
+            () => LastAccessedAtValue,
+            v => LastAccessedAtValue = v);
+    }
+
+    public string Id => _parent == null ? $"mock://{Name}" : $"{_parent.Id}/{Name}";
+    public string Name { get; }
+
+    public DateTimeOffset? CreatedAtValue { get; set; }
+    public DateTimeOffset? LastModifiedAtValue { get; set; }
+    public DateTimeOffset? LastAccessedAtValue { get; set; }
+
+    public ICreatedAtProperty CreatedAt { get; }
+    public ICreatedAtOffsetProperty CreatedAtOffset { get; }
+    public ILastModifiedAtProperty LastModifiedAt { get; }
+    public ILastModifiedAtOffsetProperty LastModifiedAtOffset { get; }
+    public ILastAccessedAtProperty LastAccessedAt { get; }
+    public ILastAccessedAtOffsetProperty LastAccessedAtOffset { get; }
+
+    public Task<IFolder?> GetParentAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IFolder?>(_parent);
+
+    public async IAsyncEnumerable<IStorableChild> GetItemsAsync(StorableType type = StorableType.All, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        LastAccessedAtValue = DateTimeOffset.UtcNow;
+
+        foreach (var child in _children)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (type == StorableType.All)
+                yield return child;
+            else if (type == StorableType.File && child is IFile)
+                yield return child;
+            else if (type == StorableType.Folder && child is IFolder)
+                yield return child;
+        }
+    }
+
+    public Task<IFolderWatcher> GetFolderWatcherAsync(CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Mock does not support folder watchers");
+
+    public Task<IChildFile> CreateFileAsync(string name, bool overwrite = false, CancellationToken cancellationToken = default)
+    {
+        var existing = _children.OfType<IChildFile>().FirstOrDefault(f => f.Name == name);
+        
+        if (existing != null)
+        {
+            if (!overwrite)
+                throw new FileAlreadyExistsException(name);
+            _children.Remove((IStorableChild)existing);
+        }
+
+        IChildFile newFile = _createFilesWithTimestamps 
+            ? new MockStorageFile(name, this)
+            : new MockStorageFileNoTimestamps(name, this);
+        
+        _children.Add((IStorableChild)newFile);
+        LastModifiedAtValue = DateTimeOffset.UtcNow;
+
+        return Task.FromResult(newFile);
+    }
+
+    public Task<IChildFolder> CreateFolderAsync(string name, bool overwrite = false, CancellationToken cancellationToken = default)
+    {
+        var existing = _children.OfType<IChildFolder>().FirstOrDefault(f => f.Name == name);
+        
+        if (existing != null)
+        {
+            if (!overwrite)
+                throw new InvalidOperationException($"Folder already exists: {name}");
+            _children.Remove((IStorableChild)existing);
+        }
+
+        var newFolder = new MockStorageFolder(name, this, _createFilesWithTimestamps);
+        _children.Add(newFolder);
+        LastModifiedAtValue = DateTimeOffset.UtcNow;
+
+        return Task.FromResult<IChildFolder>(newFolder);
+    }
+
+    public Task DeleteAsync(IStorableChild item, CancellationToken cancellationToken = default)
+    {
+        var existing = _children.FirstOrDefault(c => c.Id == item.Id);
+        if (existing == null)
+            throw new FileNotFoundException($"Item not found: {item.Name}");
+
+        _children.Remove(existing);
+        LastModifiedAtValue = DateTimeOffset.UtcNow;
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Adds an existing file to this folder (for test setup).
+    /// </summary>
+    public void AddChild(IStorableChild child)
+    {
+        _children.Add(child);
+    }
+
+    /// <summary>
+    /// Creates a pre-populated mock folder with items for testing.
+    /// </summary>
+    public static MockStorageFolder CreateWithItems(string name, int fileCount, int folderCount, bool filesWithTimestamps = true)
+    {
+        var folder = new MockStorageFolder(name, null, filesWithTimestamps);
+
+        for (int i = 0; i < fileCount; i++)
+        {
+            IStorableChild file = filesWithTimestamps
+                ? new MockStorageFile($"file_{i}.txt", folder, global::System.Text.Encoding.UTF8.GetBytes($"content {i}"))
+                : new MockStorageFileNoTimestamps($"file_{i}.txt", folder, global::System.Text.Encoding.UTF8.GetBytes($"content {i}"));
+            folder.AddChild(file);
+        }
+
+        for (int i = 0; i < folderCount; i++)
+        {
+            var subfolder = new MockStorageFolder($"folder_{i}", folder, filesWithTimestamps);
+            folder.AddChild(subfolder);
+        }
+
+        return folder;
+    }
+}
+
+/// <summary>
+/// A mock folder that creates files WITHOUT timestamp support.
+/// Used for testing cross-implementation scenarios with partial property support.
+/// </summary>
+public class MockStorageFolderNoTimestamps : IModifiableFolder, IChildFolder
+{
+    private readonly MockStorageFolderNoTimestamps? _parent;
+    private readonly List<IStorableChild> _children = new();
+
+    public MockStorageFolderNoTimestamps(string name, MockStorageFolderNoTimestamps? parent = null)
+    {
+        Name = name;
+        _parent = parent;
+    }
+
+    public string Id => _parent == null ? $"mock-no-ts://{Name}" : $"{_parent.Id}/{Name}";
+    public string Name { get; }
+
+    public Task<IFolder?> GetParentAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IFolder?>(_parent);
+
+    public async IAsyncEnumerable<IStorableChild> GetItemsAsync(StorableType type = StorableType.All, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var child in _children)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (type == StorableType.All)
+                yield return child;
+            else if (type == StorableType.File && child is IFile)
+                yield return child;
+            else if (type == StorableType.Folder && child is IFolder)
+                yield return child;
+        }
+    }
+
+    public Task<IFolderWatcher> GetFolderWatcherAsync(CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Mock does not support folder watchers");
+
+    public Task<IChildFile> CreateFileAsync(string name, bool overwrite = false, CancellationToken cancellationToken = default)
+    {
+        var existing = _children.OfType<IChildFile>().FirstOrDefault(f => f.Name == name);
+        
+        if (existing != null)
+        {
+            if (!overwrite)
+                throw new FileAlreadyExistsException(name);
+            _children.Remove((IStorableChild)existing);
+        }
+
+        var newFile = new MockStorageFileNoTimestamps(name, this);
+        _children.Add((IStorableChild)newFile);
+
+        return Task.FromResult<IChildFile>(newFile);
+    }
+
+    public Task<IChildFolder> CreateFolderAsync(string name, bool overwrite = false, CancellationToken cancellationToken = default)
+    {
+        var existing = _children.OfType<IChildFolder>().FirstOrDefault(f => f.Name == name);
+        
+        if (existing != null)
+        {
+            if (!overwrite)
+                throw new InvalidOperationException($"Folder already exists: {name}");
+            _children.Remove((IStorableChild)existing);
+        }
+
+        var newFolder = new MockStorageFolderNoTimestamps(name, this);
+        _children.Add(newFolder);
+
+        return Task.FromResult<IChildFolder>(newFolder);
+    }
+
+    public Task DeleteAsync(IStorableChild item, CancellationToken cancellationToken = default)
+    {
+        var existing = _children.FirstOrDefault(c => c.Id == item.Id);
+        if (existing == null)
+            throw new FileNotFoundException($"Item not found: {item.Name}");
+
+        _children.Remove(existing);
+        return Task.CompletedTask;
+    }
+
+    public void AddChild(IStorableChild child)
+    {
+        _children.Add(child);
+    }
+
+    public static MockStorageFolderNoTimestamps CreateWithItems(string name, int fileCount, int folderCount)
+    {
+        var folder = new MockStorageFolderNoTimestamps(name);
+
+        for (int i = 0; i < fileCount; i++)
+        {
+            var file = new MockStorageFileNoTimestamps($"file_{i}.txt", folder);
+            folder.AddChild((IStorableChild)file);
+        }
+
+        for (int i = 0; i < folderCount; i++)
+        {
+            var subfolder = new MockStorageFolderNoTimestamps($"folder_{i}", folder);
+            folder.AddChild(subfolder);
+        }
+
+        return folder;
+    }
+}

--- a/src/OwlCore.Storage.CommonTests.csproj
+++ b/src/OwlCore.Storage.CommonTests.csproj
@@ -14,7 +14,7 @@
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
 		<Author>Arlo Godfrey</Author>
-		<Version>0.5.2</Version>
+		<Version>0.6.0</Version>
 		<Product>OwlCore</Product>
 		<Description></Description>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
@@ -116,7 +116,7 @@ Initial release of OwlCore.Storage.CommonTests.
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 
 		<PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
-		<ProjectReference Include="..\..\ocstorage\src\OwlCore.Storage.csproj" />
+		<PackageReference Include="OwlCore.Storage" Version="0.15.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/OwlCore.Storage.CommonTests.csproj
+++ b/src/OwlCore.Storage.CommonTests.csproj
@@ -112,13 +112,11 @@ Initial release of OwlCore.Storage.CommonTests.
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-		<PackageReference Include="OwlCore.Extensions" Version="0.7.0" />
+		<PackageReference Include="OwlCore.Extensions" Version="0.10.0" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
-		<PackageReference Include="OwlCore.Storage" Version="0.15.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
+		<ProjectReference Include="..\..\ocstorage\src\OwlCore.Storage.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/OwlCore.Storage.CommonTests.csproj
+++ b/src/OwlCore.Storage.CommonTests.csproj
@@ -118,7 +118,7 @@ Initial release of OwlCore.Storage.CommonTests.
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
 		<PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
-		<PackageReference Include="OwlCore.Storage" Version="0.10.0" />
+		<PackageReference Include="OwlCore.Storage" Version="0.15.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/PropertyUpdateBehavior.cs
+++ b/src/PropertyUpdateBehavior.cs
@@ -1,0 +1,25 @@
+namespace OwlCore.Storage.CommonTests;
+
+/// <summary>
+/// Describes how a storage property updates in response to operations.
+/// </summary>
+public enum PropertyUpdateBehavior
+{
+    /// <summary>
+    /// The property never updates after initial value is set.
+    /// Example: CreatedAt (immutable by definition), or any timestamp on IPFS.
+    /// </summary>
+    Never,
+
+    /// <summary>
+    /// The property is updated by the time the triggering async operation completes.
+    /// Example: LastModifiedAt on local filesystem after write.
+    /// </summary>
+    Immediate,
+
+    /// <summary>
+    /// The property updates eventually, but timing is unpredictable.
+    /// Example: LastAccessedAt on cloud storage with async metadata propagation.
+    /// </summary>
+    Eventual,
+}

--- a/src/PropertyValueAvailability.cs
+++ b/src/PropertyValueAvailability.cs
@@ -1,0 +1,25 @@
+namespace OwlCore.Storage.CommonTests;
+
+/// <summary>
+/// Describes whether a storage property is expected to have a value.
+/// </summary>
+public enum PropertyValueAvailability
+{
+    /// <summary>
+    /// The property may or may not have a value depending on state or timing.
+    /// Example: LastAccessedAt on OneDrive (null until server populates it).
+    /// </summary>
+    Maybe,
+
+    /// <summary>
+    /// The property always returns a non-null value.
+    /// Example: CreatedAt on local filesystem.
+    /// </summary>
+    Always,
+
+    /// <summary>
+    /// The property never has a value (protocol doesn't support it).
+    /// Example: LastAccessedAt on FTP (not in FTP protocol).
+    /// </summary>
+    Never,
+}


### PR DESCRIPTION
This PR adds new CommonTests for the CreatedAt, LastModifiedAt, and LastAccessedAt properties introduced in OwlCore.Storage 0.15.0. 

The CI here will not pass until OwlCore.Storage 0.15.0 is shipped and available on NuGet.

Once published and passing, we can merge this and update the CommonTests on NuGet, allowing us to bring the tests into all dependent libraries being updated to the latest version of the storage abstraction. 